### PR TITLE
Filters no longer statically built into the binary, are dynamically loaded in JS

### DIFF
--- a/bin/demo.html
+++ b/bin/demo.html
@@ -30,8 +30,7 @@
       // modes
       await init('./tinysearch_engine_bg.wasm');
       const data = new Uint8Array(await fetch('/storage')
-        .then(res => res.blob())
-        .then(blob => blob.arrayBuffer())
+        .then(res => res.arrayBuffer())
       );
       window.tinysearch = new TinySearch();
       window.tinysearch.loadFilters(data);

--- a/bin/demo.html
+++ b/bin/demo.html
@@ -15,8 +15,7 @@
     // don't support natively imported WebAssembly as an ES module, but
     // eventually the manual initialization won't be required!
     // import { search, default as init } from './tinysearch_engine.js';
-    import { search, default as init } from './tinysearch_engine.js';
-    window.search = search;
+    import { TinySearch, default as init } from './tinysearch_engine.js';
 
     async function run() {
       // First up we need to actually load the wasm file, so we use the
@@ -30,6 +29,12 @@
       // exports which is the same as importing the `*_bg` module in other
       // modes
       await init('./tinysearch_engine_bg.wasm');
+      const data = new Uint8Array(await fetch('/storage')
+        .then(res => res.blob())
+        .then(blob => blob.arrayBuffer())
+      );
+      window.tinysearch = new TinySearch()
+      window.tinysearch.loadFilters(data);
     }
 
     run();
@@ -39,7 +44,7 @@
     // And afterwards we can use all the functionality defined in wasm.
     function doSearch() {
       let value = document.getElementById("demo").value;
-      const arr = search(value, 10);
+      const arr = tinysearch.search(value, 10);
       let ul = document.getElementById("results");
       ul.innerHTML = "";
 

--- a/bin/demo.html
+++ b/bin/demo.html
@@ -33,7 +33,7 @@
         .then(res => res.blob())
         .then(blob => blob.arrayBuffer())
       );
-      window.tinysearch = new TinySearch()
+      window.tinysearch = new TinySearch();
       window.tinysearch.loadFilters(data);
     }
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -13,10 +13,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bincode = "1.1.4"
-tinysearch-cuckoofilter = "0.4.0"
+js-sys = "0.3.28"
 lazy_static = "1.3.0"
-wee_alloc = "0.4.4"
+tinysearch-cuckoofilter = "0.4.0"
 tinysearch-shared = { path = "../shared", version = "0.2.0" }
+wee_alloc = "0.4.4"
 
 [dependencies.wasm-bindgen]
 version = "0.2.42"

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,40 +1,61 @@
-#[macro_use]
-extern crate lazy_static;
-
+use js_sys::Uint8Array;
 use std::cmp::Reverse;
-use std::error::Error;
 use tinysearch_shared::{Filters, PostId, Score, Storage};
 use wasm_bindgen::prelude::*;
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
-fn load_filters() -> Result<Filters, Box<Error>> {
-    let bytes = include_bytes!("../storage");
-    Ok(Storage::from_bytes(bytes)?.filters)
-}
-
-lazy_static! {
-    static ref FILTERS: Filters = load_filters().unwrap();
+#[wasm_bindgen]
+#[derive(Default)]
+pub struct TinySearch {
+    filters: Option<Filters>,
 }
 
 #[wasm_bindgen]
-pub fn search(query: String, num_results: usize) -> JsValue {
-    let search_terms: Vec<String> = query.split_whitespace().map(|s| s.to_lowercase()).collect();
+impl TinySearch {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        TinySearch::default()
+    }
 
-    let mut matches: Vec<(&PostId, u32)> = FILTERS
-        .iter()
-        .map(|(name, filter)| (name, filter.score(&search_terms)))
-        .filter(|(_, score)| *score > 0)
-        .collect();
+    #[wasm_bindgen(js_name = "loadFilters")]
+    pub fn load_filters(&mut self, data: Uint8Array) -> Result<(), JsValue> {
+        let mut buffer: Vec<u8> = vec![0; data.byte_length() as usize];
+        data.copy_to(&mut buffer);
+        self.filters = Some(
+            Storage::from_bytes(&buffer)
+                .map_err(|e| e.to_string())?
+                .filters,
+        );
+        Ok(())
+    }
 
-    matches.sort_by_key(|k| Reverse(k.1));
+    #[wasm_bindgen]
+    pub fn search(&self, query: String, num_results: usize) -> JsValue {
+        if self.filters.is_none() {
+            return JsValue::from_serde(&Vec::<Vec<&PostId>>::new()).unwrap();
+        }
 
-    let results: Vec<&PostId> = matches
-        .iter()
-        .map(|(name, _)| name.to_owned())
-        .take(num_results)
-        .collect();
+        let filters = self.filters.as_ref().unwrap();
 
-    JsValue::from_serde(&results).unwrap()
+        let search_terms: Vec<String> =
+            query.split_whitespace().map(|s| s.to_lowercase()).collect();
+
+        let mut matches: Vec<(&PostId, u32)> = filters
+            .iter()
+            .map(|(name, filter)| (name, filter.score(&search_terms)))
+            .filter(|(_, score)| *score > 0)
+            .collect();
+
+        matches.sort_by_key(|k| Reverse(k.1));
+
+        let results: Vec<&PostId> = matches
+            .iter()
+            .map(|(name, _)| name.to_owned())
+            .take(num_results)
+            .collect();
+
+        JsValue::from_serde(&results).unwrap()
+    }
 }


### PR DESCRIPTION
Just a proof of concept for now - should solve the compile times issue since the wasm can be compiled once and then filters generated separately.
To test, build the project as normal then overwrite the .wasm files by running (in the `engine` dir):

`tinysearch/engine $ wasm-pack build --target web --release --out-dir ../`

Next steps:
1. Separate out the wasm from the filter generation, publish to npm
2. Build a cli for generating the filters

Let me know if you think it's worth continuing

Cheers,

P