### PR TITLE
add binaryen install to use -o switch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ FROM $RUST_IMAGE
 
 WORKDIR /tmp
 
-RUN apk add --update --no-cache libc6-compat musl-dev
+RUN apk add --update --no-cache libc6-compat musl-dev binaryen
 
 RUN set -eux -o pipefail; \
     ln -s /lib64/ld-linux-x86-64.so.2 /lib/ld64.so.1;


### PR DESCRIPTION
Install binaryen on alpine to use the -o switch with the Docker image