### PR TITLE
Make body field optional

### DIFF
--- a/bin/src/index.rs
+++ b/bin/src/index.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct Post {
     pub title: String,
     pub url: String,
-    pub body: String,
+    pub body: Option<String>,
 }
 
 pub type Posts = Vec<Post>;

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -6,12 +6,12 @@ mod storage;
 mod strip_markdown;
 
 use anyhow::{Context, Error, Result};
+use argh::FromArgs;
 use lazy_static::lazy_static;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::{env, fs};
-use argh::FromArgs;
 use tempfile::tempdir;
 
 use fs::File;


### PR DESCRIPTION
Post body now is an optional field.

I have changed the test because there is a case mismatch when [transforming words](https://github.com/tinysearch/tinysearch/blob/master/bin/src/storage.rs#L53) before adding to filter.

Resolves #117.