### PR TITLE
add -v flag to docker run command in README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-# Docker tinsearch with deps
+# Docker tinysearch with deps
 #   - binaryen
 #   - wasm-pack
 #   - terser
-# For nightly rust toolset use build arg RUST_IMAGE=rustlang/rust:nightly-alpine
-#
-ARG WASM_REPO=https://github.com/mre/wasm-pack.git
-ARG WASM_BRANCH=first-class-bins
+
 ARG TINY_REPO=https://github.com/tinysearch/tinysearch
 ARG TINY_BRANCH=master
 ARG RUST_IMAGE=rust:alpine
 
-FROM $RUST_IMAGE as binary-build
+FROM $RUST_IMAGE AS binary-build
 
 ARG WASM_REPO
 ARG WASM_BRANCH
@@ -22,27 +19,18 @@ WORKDIR /tmp
 
 RUN apk add --update --no-cache --virtual build-dependencies musl-dev openssl-dev gcc curl git npm gcc ca-certificates libc6-compat binaryen
 
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    WASM_REPO="$WASM_REPO" \
-    WASM_BRANCH="$WASM_BRANCH" \
-    TINY_REPO="$TINY_REPO" \
-    TINY_BRANCH="$TINY_BRANCH"
-
 RUN set -eux -o pipefail; \
     ln -s /lib64/ld-linux-x86-64.so.2 /lib/ld64.so.1; \
     npm install terser -g;
 
-RUN time cargo install --force --git "$WASM_REPO" --branch "$WASM_BRANCH"
-
 RUN cd /tmp && git clone --branch "$TINY_BRANCH" "$TINY_REPO"
+
+RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
 # https://github.com/tinysearch/tinysearch/issues/111
 RUN set -ex -o pipefail; cd /tmp/tinysearch && if ! [[ -z $TINY_MAGIC ]]; then sed -i.bak bin/src/storage.rs -e "s/let mut filter = CuckooFilter::with_capacity(words.len() + .*);/let mut filter = CuckooFilter::with_capacity(words.len() + $TINY_MAGIC);/g";fi && cargo build --release && cp target/release/tinysearch $CARGO_HOME/bin && echo $TINY_MAGIC |tee /.tinymagic
 
 RUN wasm-pack --version
-RUN tinysearch --version
 
 FROM $RUST_IMAGE
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Available buid args:
 
 ```
 wget https://raw.githubusercontent.com/tinysearch/tinysearch/master/fixtures/index.json
-docker run $PWD:/tmp tinysearch/cli index.json
+docker run -v $PWD:/tmp tinysearch/cli index.json
 ```
 
 Custom repo/branch build


### PR DESCRIPTION
in README.md change
`docker run $PWD:/tmp tinysearch/cli output/json.html` 
to
`docker run -v $PWD:/tmp tinysearch/cli output/json.html`