### PR TITLE
change default output folder to ./wasm_output instead of local dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ tinysearch_engine_bg.d.ts
 tinysearch_engine_bg.wasm.d.ts
 package.json
 pkg/
+wasm_output/
 demo.html
 .vscode

--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -74,7 +74,10 @@ fn main() -> Result<(), Error> {
 
     let out_path = opt
         .out_path
-        .unwrap_or_else(|| PathBuf::from("."))
+        .unwrap_or_else(|| {
+            fs::create_dir_all("./wasm_output").unwrap();
+            PathBuf::from("./wasm_output")
+        })
         .canonicalize()?;
 
     let index = opt.index.context("No index file specified")?;
@@ -92,7 +95,7 @@ fn main() -> Result<(), Error> {
 
     let engine_dir = temp_dir.path().join("engine");
     if !engine_dir.exists() {
-      fs::create_dir_all(&engine_dir)?;
+        fs::create_dir_all(&engine_dir)?;
     }
     if !engine_dir.exists() {
         for path in fs::read_dir(out_path)? {


### PR DESCRIPTION
When I was running tinysearch locally and ran ```cargo run fixtures/index.json```, it was wiping my local repository and replacing it with the wasm output.

The above PR changes the default directory when no output directory is specified to a "wasm_output" dir created in the local directory.

I'm curious about how the current tinysearch cargo build would work in another web project and if it would delete all the files and replace them with the wasm output.

Also please excuse if there's anything wrong with my code, I'm new to Rust.