### PR TITLE
meta field

### DIFF
--- a/bin/src/index.rs
+++ b/bin/src/index.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct Post {
     pub title: String,
     pub url: String,
+    pub meta: Option<String>,
     pub body: Option<String>,
 }
 

--- a/bin/src/storage.rs
+++ b/bin/src/storage.rs
@@ -97,10 +97,11 @@ mod tests {
         let mut posts = HashMap::new();
         posts.insert(
             (
-                "Maybe You Don't Need Kubernetes, Or Excel - You Know".to_string(),
-                "".to_string(),
+                "Maybe You Don't Need Kubernetes, Or Excel - You Know".to_string(),//title
+                "".to_string(),//url
+                None,//meta
             ),
-            None,
+            None,//body
         );
         let filters = generate_filters(posts).unwrap();
         assert_eq!(filters.len(), 1);

--- a/bin/src/storage.rs
+++ b/bin/src/storage.rs
@@ -81,7 +81,7 @@ pub fn prepare_posts(posts: Posts) -> HashMap<PostId, Option<String>> {
     let mut prepared: HashMap<PostId, Option<String>> = HashMap::new();
     for post in posts {
         debug!("Analyzing {}", post.url);
-        prepared.insert((post.title, post.url), post.body);
+        prepared.insert((post.title, post.url, post.meta), post.body);
     }
     prepared
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -7,7 +7,8 @@ use std::collections::hash_map::DefaultHasher;
 
 type Title = String;
 type Url = String;
-pub type PostId = (Title, Url);
+type Meta = Option<String>;
+pub type PostId = (Title, Url, Meta);
 pub type PostFilter = (PostId, HashProxy<String, DefaultHasher, Xor8>);
 pub type Filters = Vec<PostFilter>;
 


### PR DESCRIPTION
Closes #159 

Add optional meta field. Can be used for short page description, etc, to return more information with results, for example:

![tinysearch-meta](https://user-images.githubusercontent.com/106644/183518911-5d6d5f4d-2bda-4b14-9245-003c5edffee8.gif)
