### PR TITLE
#165 Failing to find Cargo.toml in temp directory

### DIFF
--- a/bin/build.rs
+++ b/bin/build.rs
@@ -4,8 +4,8 @@ use includedir_codegen::Compression;
 
 fn main() {
     includedir_codegen::start("FILES")
-        .dir("../engine", Compression::Gzip)
-        .dir("../shared", Compression::Gzip)
+        .dir(concat!(env!("OUT_DIR"),"/engine"), Compression::Gzip)
+        .dir(concat!(env!("OUT_DIR"),"/shared"), Compression::Gzip)
         .build("engine.rs")
         .unwrap();
 }

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -4,8 +4,8 @@ use includedir_codegen::Compression;
 
 fn main() {
     includedir_codegen::start("FILES")
-        .dir(concat!(env!("OUT_DIR"),"/engine"), Compression::Gzip)
-        .dir(concat!(env!("OUT_DIR"),"/shared"), Compression::Gzip)
+        .dir(format!("{}{}",std::env::var("OUT_DIR").unwrap(),"/engine"), Compression::Gzip)
+        .dir(format!("{}{}",std::env::var("OUT_DIR").unwrap(),"/shared"), Compression::Gzip)
         .build("engine.rs")
         .unwrap();
 }


### PR DESCRIPTION
@ASMfreaK's solution worked for me using cd bin; cargo install --path .

Wanted to help get a solution into tree for normal cargo install.  I'm not sure that this is the solution.

When I run it, using cargo install --path .;
```

error: environment variable `OUT_DIR` not defined
 --> bin\build.rs:7:22
  |
7 |         .dir(concat!(env!("OUT_DIR"),"/engine"), Compression::Gzip)
  |                      ^^^^^^^^^^^^^^^
  |
  = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)

error: environment variable `OUT_DIR` not defined
 --> bin\build.rs:8:22
  |
8 |         .dir(concat!(env!("OUT_DIR"),"/shared"), Compression::Gzip)
```

OUT_DIR isn't defined for a standard cargo install --path . invoke.