### PR TITLE
Add lazy, content-addressed sharded indexes for exact WASM search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Install Node.js for generated loader tests
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,10 +72,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "equivalent"
@@ -98,6 +136,16 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getopts"
@@ -289,6 +337,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strip_markdown"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "tinysearch"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "argh",
@@ -364,6 +423,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "sha2",
  "strip_markdown",
  "strum",
  "tempfile",
@@ -425,6 +485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +513,12 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtue"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinysearch"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Matthias Endler <matthias-endler@gmx.net>"]
 edition = "2024"
 rust-version = "1.85"
@@ -23,6 +23,7 @@ required-features = ["bin"]
 
 [dependencies]
 bincode = { version = "2.0.1", features = ["serde"] }
+sha2 = { version = "0.10.9", default-features = false }
 
 argh = { version = "0.1.19", optional = true }
 log = { version = "0.4.33", optional = true }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ that map each word to the articles containing it. Document IDs are delta- and
 varint-encoded, which keeps the index compact and compressible. Exact and prefix
 searches use the same index and do not introduce probabilistic false positives.
 
+WASM builds split the exact vocabulary into immutable lexical shards. A small
+root routes each query to the relevant content-addressed shards, which the
+JavaScript loader fetches and caches on demand. The WASM engine is independent
+of corpus size and validates each shard before merging it into the live index.
+See [Sharded indexes](docs/sharded-index.md) for the format, cache model, tests,
+and initial size measurements.
+
 The optional `xor8` indexer creates smaller probabilistic per-article filters.
 It supports title prefixes, but body and metadata searches require complete
 words. Previously generated Xor-filter indexes use this same path.
@@ -46,9 +53,11 @@ words. Previously generated Xor-filter indexes use this same path.
 - With the default exact indexer, prefix matching starts once a query term
   reaches three characters. Shorter terms require an exact match.
 - The `xor8` indexer only supports prefixes in titles.
-- Since we bundle all search indices for all articles into one static binary, we
-  recommend to only use it for small- to medium-size websites. Expect around 2
-  kB uncompressed per article (~1 kb compressed).
+- Query-selective lazy loading is available for the default exact backend. The
+  optional Xor8 backend still embeds its complete index in the WASM module.
+- Loaded exact shards remain in WASM memory for the lifetime of the engine. A
+  long session that searches the entire vocabulary can eventually load the
+  complete index.
 
 ## Installation
 
@@ -108,7 +117,29 @@ tinysearch --release -o -m wasm -p wasm_output fixtures/index.json
 tinysearch --indexer xor8 -m wasm -p wasm_output fixtures/index.json
 ```
 
-This creates a dependency-free WASM module using vanilla `cargo build` instead of `wasm-pack`.
+This creates a dependency-free ES module loader, a corpus-independent WASM
+engine, `tinysearch.root`, and content-addressed `.tinysearch-shard` files using
+vanilla `cargo build` instead of `wasm-pack`. The default raw shard target is
+64 KiB; tune it with `--shard-size`, for example `--shard-size 32768`.
+
+Load and search it with:
+
+```js
+import { initTinysearch } from './tinysearch_engine.js';
+
+const engine = await initTinysearch();
+const results = await engine.search('rust wasm', 10);
+```
+
+The loader resolves the root, WASM, and shards relative to its own module URL.
+Custom URLs and a custom `fetch` implementation can also be supplied.
+
+### Migrating from 0.11
+
+Version 0.12 makes the generated loader's `search()` method asynchronous for
+both exact and Xor8 indexes. Callers must `await engine.search(...)`. The
+original `init_tinysearch()` initializer remains available as an alias, but the
+camel-case `initTinysearch()` spelling is preferred.
 
 ## Demo
 
@@ -222,7 +253,9 @@ tinysearch --help
 
 Please check what's required to
 [host WebAssembly in production](https://rustwasm.github.io/book/reference/deploying-to-production.html)
--- you will need to explicitly set gzip mime types.
+-- serve the WASM file as `application/wasm` and enable Brotli or gzip for the
+WASM, root, loader, and shards. Content-addressed shards can use immutable cache
+headers; the root should be revalidated.
 
 ## Docker
 

--- a/assets/crate/Cargo.toml.template
+++ b/assets/crate/Cargo.toml.template
@@ -3,7 +3,7 @@
 [package]
 name = "THIS_VALUE_SHOULD_BE_FILLED"
 authors = ["Matthias Endler <matthias-endler@gmx.net>"]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A tiny search engine for static websites"

--- a/assets/crate/src/lib.rs
+++ b/assets/crate/src/lib.rs
@@ -6,6 +6,32 @@ use tinysearch::{PostId, SearchIndex, Storage, search as base_search};
 
 static SEARCH_INDEX: OnceLock<SearchIndex> = OnceLock::new();
 
+/// Allocates an input buffer for the generated JavaScript loader.
+#[unsafe(no_mangle)]
+pub extern "C" fn alloc_query(len: usize) -> *mut u8 {
+    if len == 0 {
+        return std::ptr::null_mut();
+    }
+    Box::into_raw(vec![0_u8; len].into_boxed_slice()).cast::<u8>()
+}
+
+/// Releases an input buffer returned by [`alloc_query`].
+///
+/// # Safety
+///
+/// `ptr` and `len` must identify a still-live allocation returned by exactly one
+/// `alloc_query(len)` call, and the pointer must not be used afterwards.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn free_query(ptr: *mut u8, len: usize) {
+    if ptr.is_null() || len == 0 {
+        return;
+    }
+
+    let slice = std::ptr::slice_from_raw_parts_mut(ptr, len);
+    // SAFETY: The caller must uphold the matching-allocation contract above.
+    drop(unsafe { Box::from_raw(slice) });
+}
+
 pub fn search_local(query: String, num_results: usize) -> Vec<&'static PostId> {
     let index = SEARCH_INDEX.get_or_init(|| {
         let bytes = include_bytes!("storage");

--- a/assets/crate/src/sharded_lib.rs
+++ b/assets/crate/src/sharded_lib.rs
@@ -1,0 +1,361 @@
+//! Raw WebAssembly ABI for a corpus-independent sharded tinysearch engine.
+//!
+//! The generated module owns one [`ShardedIndex`] and a table of JSON response
+//! buffers. JavaScript passes byte slices as pointer/length pairs allocated by
+//! [`engine_alloc`] and reads responses through opaque handles.
+
+use std::alloc::{Layout, alloc, dealloc};
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::ptr;
+use std::slice;
+use std::str;
+
+use serde_json::{Value, json};
+use tinysearch::{ShardError, ShardId, ShardedIndex};
+
+const ENGINE_ABI_VERSION: u32 = 1;
+
+type ResultHandle = u32;
+
+struct EngineState {
+    index: Option<ShardedIndex>,
+    results: BTreeMap<ResultHandle, Box<[u8]>>,
+    next_handle: ResultHandle,
+}
+
+impl EngineState {
+    fn new() -> Self {
+        Self {
+            index: None,
+            results: BTreeMap::new(),
+            next_handle: 1,
+        }
+    }
+
+    fn insert_result(&mut self, bytes: Box<[u8]>) -> ResultHandle {
+        if self.results.len() >= u32::MAX as usize {
+            return 0;
+        }
+
+        loop {
+            let handle = self.next_handle.max(1);
+            self.next_handle = handle.wrapping_add(1).max(1);
+            if let std::collections::btree_map::Entry::Vacant(entry) = self.results.entry(handle) {
+                entry.insert(bytes);
+                return handle;
+            }
+        }
+    }
+}
+
+thread_local! {
+    static ENGINE: RefCell<EngineState> = RefCell::new(EngineState::new());
+}
+
+fn error_response(code: &str, error: impl std::fmt::Display) -> Value {
+    json!({
+        "ok": false,
+        "code": code,
+        "error": error.to_string(),
+    })
+}
+
+fn shard_list(index: &ShardedIndex, ids: &[ShardId]) -> Value {
+    Value::Array(
+        ids.iter()
+            .filter_map(|id| {
+                index
+                    .descriptors()
+                    .iter()
+                    .find(|descriptor| descriptor.id == *id)
+                    .map(|descriptor| {
+                        json!({
+                            "id": descriptor.id.get(),
+                            "filename": descriptor.filename,
+                        })
+                    })
+            })
+            .collect(),
+    )
+}
+
+fn store_response(response: Value) -> ResultHandle {
+    let bytes = serde_json::to_vec(&response).unwrap_or_else(|error| {
+        format!(
+            "{{\"ok\":false,\"code\":\"json_serialization\",\"error\":{}}}",
+            serde_json::to_string(&error.to_string())
+                .unwrap_or_else(|_| "\"failed to serialize engine response\"".to_owned())
+        )
+        .into_bytes()
+    });
+    ENGINE.with_borrow_mut(|state| state.insert_result(bytes.into_boxed_slice()))
+}
+
+/// Borrows an ABI input region.
+///
+/// # Safety
+///
+/// For nonzero `len`, `ptr` must point to `len` initialized bytes in this
+/// module's linear memory. The region must remain live and unmodified for the
+/// duration of the call. Callers satisfy this by using [`engine_alloc`],
+/// writing exactly `len` bytes, and calling [`engine_dealloc`] afterwards.
+unsafe fn input_bytes<'input>(ptr: *const u8, len: usize) -> Result<&'input [u8], Value> {
+    if len == 0 {
+        return Ok(&[]);
+    }
+    if ptr.is_null() {
+        return Err(error_response(
+            "invalid_pointer",
+            "a null input pointer was supplied with a nonzero length",
+        ));
+    }
+
+    // SAFETY: The raw ABI caller must uphold the allocation, bounds, lifetime,
+    // and initialization invariants documented above.
+    Ok(unsafe { slice::from_raw_parts(ptr, len) })
+}
+
+/// Decodes one UTF-8 ABI input without accepting replacement characters.
+///
+/// # Safety
+///
+/// The caller must uphold the same memory invariants as [`input_bytes`].
+unsafe fn input_string<'input>(ptr: *const u8, len: usize) -> Result<&'input str, Value> {
+    // SAFETY: Forwarded directly from this function's contract.
+    let bytes = unsafe { input_bytes(ptr, len) }?;
+    str::from_utf8(bytes)
+        .map_err(|error| error_response("invalid_utf8", format!("query is not UTF-8: {error}")))
+}
+
+/// Returns the raw engine ABI version.
+#[unsafe(no_mangle)]
+pub extern "C" fn engine_abi_version() -> u32 {
+    ENGINE_ABI_VERSION
+}
+
+/// Allocates `len` bytes in WASM linear memory for an ABI input.
+///
+/// Returns null for a zero length, an invalid layout, or allocation failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn engine_alloc(len: usize) -> *mut u8 {
+    if len == 0 {
+        return ptr::null_mut();
+    }
+    let Ok(layout) = Layout::array::<u8>(len) else {
+        return ptr::null_mut();
+    };
+
+    // SAFETY: `layout` is nonzero and valid. Ownership of the returned region
+    // crosses the raw ABI and must be returned to `engine_dealloc` with `len`.
+    unsafe { alloc(layout) }
+}
+
+/// Frees an input region returned by [`engine_alloc`].
+///
+/// # Safety
+///
+/// For nonzero `len`, `ptr` must be the still-live pointer returned by exactly
+/// one `engine_alloc(len)` call and must not be used after this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn engine_dealloc(ptr: *mut u8, len: usize) {
+    if ptr.is_null() || len == 0 {
+        return;
+    }
+    let Ok(layout) = Layout::array::<u8>(len) else {
+        return;
+    };
+
+    // SAFETY: The raw ABI caller must uphold the matching-allocation invariant
+    // documented above.
+    unsafe { dealloc(ptr, layout) };
+}
+
+/// Decodes and installs a new root index, returning a JSON response handle.
+///
+/// A successful replacement discards loaded shards and outstanding response
+/// buffers from the previous generation. Result handle allocation keeps
+/// advancing so stale handles cannot alias new responses after a reload. A
+/// malformed replacement leaves the current valid index intact.
+///
+/// # Safety
+///
+/// `ptr` and `len` must satisfy the input invariants documented on
+/// [`input_bytes`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn engine_load_root(ptr: *const u8, len: usize) -> ResultHandle {
+    // SAFETY: Forwarded directly from this function's contract.
+    let bytes = match unsafe { input_bytes(ptr, len) } {
+        Ok(bytes) => bytes,
+        Err(response) => return store_response(response),
+    };
+
+    match ShardedIndex::from_root_bytes(bytes) {
+        Ok(index) => {
+            let shard_count = index.descriptors().len();
+            ENGINE.with_borrow_mut(|state| {
+                state.index = Some(index);
+                state.results.clear();
+            });
+            store_response(json!({
+                "ok": true,
+                "shardCount": shard_count,
+                "loadedShardCount": 0,
+                "loadedShardBytes": 0,
+            }))
+        }
+        Err(error) => store_response(error_response("invalid_root", error)),
+    }
+}
+
+/// Plans all lexical shards needed for a UTF-8 query.
+///
+/// # Safety
+///
+/// `ptr` and `len` must satisfy the input invariants documented on
+/// [`input_bytes`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn engine_plan_query(ptr: *const u8, len: usize) -> ResultHandle {
+    // SAFETY: Forwarded directly from this function's contract.
+    let query = match unsafe { input_string(ptr, len) } {
+        Ok(query) => query,
+        Err(response) => return store_response(response),
+    };
+
+    let response = ENGINE.with_borrow(|state| match state.index.as_ref() {
+        Some(index) => {
+            let required = index.required_shards(query);
+            json!({
+                "ok": true,
+                "required": shard_list(index, &required),
+                "loadedShardCount": index.loaded_shard_count(),
+                "loadedShardBytes": index.loaded_shard_bytes(),
+            })
+        }
+        None => error_response("not_initialized", "no sharded root has been loaded"),
+    });
+    store_response(response)
+}
+
+/// Validates and installs one lexical shard from its encoded bytes.
+///
+/// # Safety
+///
+/// `ptr` and `len` must satisfy the input invariants documented on
+/// [`input_bytes`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn engine_load_shard(ptr: *const u8, len: usize) -> ResultHandle {
+    // SAFETY: Forwarded directly from this function's contract.
+    let bytes = match unsafe { input_bytes(ptr, len) } {
+        Ok(bytes) => bytes,
+        Err(response) => return store_response(response),
+    };
+
+    let response = ENGINE.with_borrow_mut(|state| {
+        let Some(index) = state.index.as_mut() else {
+            return error_response("not_initialized", "no sharded root has been loaded");
+        };
+
+        match index.load_shard(bytes) {
+            Ok(id) => {
+                let filename = index
+                    .descriptors()
+                    .iter()
+                    .find(|descriptor| descriptor.id == id)
+                    .map(|descriptor| descriptor.filename.as_str());
+                json!({
+                    "ok": true,
+                    "id": id.get(),
+                    "filename": filename,
+                    "loadedShardCount": index.loaded_shard_count(),
+                    "loadedShardBytes": index.loaded_shard_bytes(),
+                })
+            }
+            Err(error) => error_response("invalid_shard", error),
+        }
+    });
+    store_response(response)
+}
+
+/// Searches the currently loaded shard set and returns a JSON response handle.
+///
+/// If shards are missing, the error response includes their IDs and filenames
+/// in `needs`; malformed UTF-8 and malformed state are also returned as JSON.
+///
+/// # Safety
+///
+/// `ptr` and `len` must satisfy the input invariants documented on
+/// [`input_bytes`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn engine_search(ptr: *const u8, len: usize, limit: usize) -> ResultHandle {
+    // SAFETY: Forwarded directly from this function's contract.
+    let query = match unsafe { input_string(ptr, len) } {
+        Ok(query) => query,
+        Err(response) => return store_response(response),
+    };
+
+    let response = ENGINE.with_borrow(|state| {
+        let Some(index) = state.index.as_ref() else {
+            return error_response("not_initialized", "no sharded root has been loaded");
+        };
+
+        match index.search(query, limit) {
+            Ok(posts) => {
+                let results: Vec<Value> = posts
+                    .into_iter()
+                    .map(|post| {
+                        json!({
+                            "title": post.title,
+                            "url": post.url,
+                            "meta": post.meta,
+                        })
+                    })
+                    .collect();
+                json!({
+                    "ok": true,
+                    "results": results,
+                    "loadedShardCount": index.loaded_shard_count(),
+                    "loadedShardBytes": index.loaded_shard_bytes(),
+                })
+            }
+            Err(ShardError::NeedsShards(ids)) => json!({
+                "ok": false,
+                "code": "needs_shards",
+                "error": "query requires lexical shards that are not loaded",
+                "needs": shard_list(index, &ids),
+            }),
+            Err(error) => error_response("search_failed", error),
+        }
+    });
+    store_response(response)
+}
+
+/// Returns the pointer for an outstanding JSON response handle.
+///
+/// The pointer remains valid until [`engine_result_free`] is called for the
+/// handle. Unknown handles return null.
+#[unsafe(no_mangle)]
+pub extern "C" fn engine_result_ptr(handle: ResultHandle) -> *const u8 {
+    ENGINE.with_borrow(|state| {
+        state
+            .results
+            .get(&handle)
+            .map_or(ptr::null(), |bytes| bytes.as_ptr())
+    })
+}
+
+/// Returns the byte length for an outstanding JSON response handle.
+///
+/// Unknown handles return zero.
+#[unsafe(no_mangle)]
+pub extern "C" fn engine_result_len(handle: ResultHandle) -> usize {
+    ENGINE.with_borrow(|state| state.results.get(&handle).map_or(0, |bytes| bytes.len()))
+}
+
+/// Releases an opaque JSON response handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn engine_result_free(handle: ResultHandle) {
+    ENGINE.with_borrow_mut(|state| {
+        state.results.remove(&handle);
+    });
+}

--- a/assets/demo.html
+++ b/assets/demo.html
@@ -1,272 +1,220 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>TinySearch WASM Demo</title>
     <style>
+        :root {
+            color-scheme: light dark;
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+
         body {
-            font-family: system-ui, -apple-system, sans-serif;
-            max-width: 800px;
+            max-width: 50rem;
             margin: 0 auto;
-            padding: 40px 20px;
-            background-color: #f8f9fa;
+            padding: 2.5rem 1.25rem;
+            background: Canvas;
+            color: CanvasText;
         }
-        
+
         .container {
-            background: white;
-            padding: 30px;
-            border-radius: 8px;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            padding: 1.75rem;
+            border: 1px solid color-mix(in srgb, CanvasText 18%, transparent);
+            border-radius: 0.75rem;
         }
-        
-        h1 {
-            color: #2c3e50;
-            margin-bottom: 20px;
-        }
-        
+
         .search-box {
-            margin: 20px 0;
+            display: flex;
+            gap: 0.5rem;
+            margin: 1.25rem 0 0.5rem;
         }
-        
-        input[type="text"] {
-            width: 300px;
-            padding: 10px;
-            border: 2px solid #e1e8ed;
-            border-radius: 4px;
-            font-size: 16px;
+
+        input {
+            flex: 1;
+            min-width: 0;
+            padding: 0.7rem;
+            border: 2px solid color-mix(in srgb, CanvasText 20%, transparent);
+            border-radius: 0.4rem;
+            font: inherit;
         }
-        
+
         button {
-            padding: 10px 20px;
-            background: #3498db;
-            color: white;
-            border: none;
-            border-radius: 4px;
+            padding: 0.7rem 1rem;
+            border: 0;
+            border-radius: 0.4rem;
+            background: LinkText;
+            color: Canvas;
+            font: inherit;
             cursor: pointer;
-            font-size: 16px;
-            margin-left: 10px;
         }
-        
-        button:hover {
-            background: #2980b9;
-        }
-        
-        .results {
-            margin-top: 20px;
-        }
-        
-        .result-item {
-            padding: 15px;
-            border: 1px solid #e1e8ed;
-            border-radius: 4px;
-            margin-bottom: 10px;
-            background: #f8f9fa;
-        }
-        
-        .result-title {
-            font-weight: bold;
-            color: #3498db;
-            text-decoration: none;
-            font-size: 16px;
-        }
-        
-        .result-title:hover {
-            text-decoration: underline;
-        }
-        
-        .no-results {
-            color: #7f8c8d;
-            font-style: italic;
-        }
-        
+
         .status {
-            color: #7f8c8d;
-            font-size: 14px;
-            margin-top: 10px;
+            min-height: 1.5em;
+            color: GrayText;
         }
-        
-        .error {
-            color: #e74c3c;
-            background: #fdf2f2;
-            padding: 10px;
-            border-radius: 4px;
-            margin-top: 10px;
+
+        .status.error {
+            color: #c62828;
+        }
+
+        .results {
+            display: grid;
+            gap: 0.65rem;
+            margin-top: 1rem;
+            padding: 0;
+            list-style: none;
+        }
+
+        .result-item {
+            padding: 0.9rem;
+            border: 1px solid color-mix(in srgb, CanvasText 15%, transparent);
+            border-radius: 0.4rem;
+        }
+
+        .result-title {
+            font-weight: 650;
         }
     </style>
 </head>
 <body>
-    <div class="container">
+    <main class="container">
         <h1>TinySearch WASM Demo</h1>
-        <p>This demo shows TinySearch running in WebAssembly. Results update as you type. Try terms like "rust", "javascript", or "blog".</p>
-        
-        <div class="search-box">
-            <input type="text" id="searchInput" placeholder="Start typing to search..." aria-label="Search" aria-controls="results" />
-            <button type="button" onclick="performSearch()">Search</button>
-        </div>
-        
-        <div id="status" class="status" role="status" aria-live="polite">Loading search engine...</div>
-        <div id="results" class="results" aria-live="polite"></div>
-    </div>
+        <p>Results update as you type. The selected backend loads the search data it needs.</p>
 
-    <script>
-        let wasmModule = null;
-        let memory = null;
-        let searchFunction = null;
-        let freeFunction = null;
-        
-        async function initializeSearch() {
-            try {
-                const response = await fetch('./{WASM_NAME}.wasm');
-                if (!response.ok) {
-                    throw new Error(`Failed to fetch WASM: ${response.status} ${response.statusText}`);
-                }
-                
-                const wasmBytes = await response.arrayBuffer();
-                const module = await WebAssembly.instantiate(wasmBytes);
-                
-                wasmModule = module.instance;
-                memory = wasmModule.exports.memory;
-                searchFunction = wasmModule.exports.search;
-                freeFunction = wasmModule.exports.free_search_result;
-                
-                if (!searchFunction || !freeFunction || !memory) {
-                    throw new Error('Required WASM exports not found');
-                }
-                
-                document.getElementById('status').textContent = 'Search engine ready. Start typing to see results.';
-                document.getElementById('searchInput').disabled = false;
-                document.getElementById('searchInput').focus();
-                
-            } catch (error) {
-                console.error('Failed to initialize search:', error);
-                document.getElementById('status').innerHTML = `<div class="error">Failed to initialize search: ${error.message}</div>`;
-            }
-        }
-        
-        function stringToWasmPtr(str) {
-            const bytes = new TextEncoder().encode(str + '\0');
-            const ptr = wasmModule.exports.__wbindgen_malloc(bytes.length);
-            if (!ptr) {
-                // Fallback: write to a known memory location
-                const memoryArray = new Uint8Array(memory.buffer);
-                const startOffset = 1024; // Use a safe offset
-                memoryArray.set(bytes, startOffset);
-                return startOffset;
-            }
-            new Uint8Array(memory.buffer, ptr, bytes.length).set(bytes);
-            return ptr;
-        }
-        
-        function wasmPtrToString(ptr) {
-            if (ptr === 0) return null;
-            
-            const memoryArray = new Uint8Array(memory.buffer);
-            let length = 0;
-            
-            // Find the null terminator
-            while (memoryArray[ptr + length] !== 0) {
-                length++;
-                if (length > 1000000) break; // Safety limit
-            }
-            
-            const bytes = memoryArray.slice(ptr, ptr + length);
-            return new TextDecoder().decode(bytes);
-        }
-        
-        function performSearch() {
-            const query = document.getElementById('searchInput').value.trim();
-            const resultsDiv = document.getElementById('results');
-            const statusDiv = document.getElementById('status');
-            
-            if (!wasmModule) {
-                statusDiv.innerHTML = '<div class="error">Search engine not initialized</div>';
-                return;
-            }
-            
-            if (!query) {
-                resultsDiv.innerHTML = '';
-                statusDiv.textContent = 'Enter a search query to see results.';
-                return;
-            }
-            
-            try {
-                const startTime = performance.now();
-                
-                // Allocate memory for query string
-                let queryPtr;
-                try {
-                    queryPtr = stringToWasmPtr(query);
-                } catch (e) {
-                    // Fallback: use a fixed memory location
-                    const queryBytes = new TextEncoder().encode(query + '\0');
-                    const memoryArray = new Uint8Array(memory.buffer);
-                    queryPtr = 1024; // Fixed offset
-                    memoryArray.set(queryBytes, queryPtr);
-                }
-                
-                // Call search function
-                const resultPtr = searchFunction(queryPtr, 10);
-                
-                // Free query memory if we allocated it
-                if (wasmModule.exports.__wbindgen_free && queryPtr > 1024) {
-                    wasmModule.exports.__wbindgen_free(queryPtr, query.length + 1);
-                }
-                
-                const endTime = performance.now();
-                const searchTime = (endTime - startTime).toFixed(3);
-                
-                if (resultPtr === 0) {
-                    resultsDiv.innerHTML = '<div class="no-results">No results found</div>';
-                    statusDiv.textContent = `No results found for "${query}" (${searchTime}ms)`;
-                    return;
-                }
-                
-                // Read result string
-                const resultString = wasmPtrToString(resultPtr);
-                
-                // Free result memory
-                freeFunction(resultPtr);
-                
-                if (!resultString) {
-                    resultsDiv.innerHTML = '<div class="no-results">No results found</div>';
-                    statusDiv.textContent = `No results found for "${query}" (${searchTime}ms)`;
-                    return;
-                }
-                
-                const results = JSON.parse(resultString);
-                
-                if (results.length === 0) {
-                    resultsDiv.innerHTML = '<div class="no-results">No results found</div>';
-                    statusDiv.textContent = `No results found for "${query}" (${searchTime}ms)`;
-                } else {
-                    const resultHTML = results.map(result => `
-                        <div class="result-item">
-                            <a href="${result.url}" class="result-title" target="_blank">${result.title}</a>
-                        </div>
-                    `).join('');
-                    
-                    resultsDiv.innerHTML = resultHTML;
-                    statusDiv.textContent = `Found ${results.length} result${results.length !== 1 ? 's' : ''} for "${query}" (${searchTime}ms)`;
-                }
-                
-            } catch (error) {
-                console.error('Search error:', error);
-                resultsDiv.innerHTML = '<div class="error">Search failed. Check console for details.</div>';
-                statusDiv.innerHTML = `<div class="error">Search failed: ${error.message}</div>`;
-            }
-        }
-        
+        <div class="search-box">
+            <input
+                type="search"
+                id="searchInput"
+                placeholder="Start typing to search…"
+                aria-label="Search"
+                aria-controls="results"
+                autocomplete="off"
+                disabled
+            >
+            <button type="button" id="searchButton" disabled>Search</button>
+        </div>
+
+        <div id="status" class="status" role="status" aria-live="polite">
+            Loading search engine…
+        </div>
+        <ol id="results" class="results" aria-live="polite"></ol>
+    </main>
+
+    <script type="module">
+        import { initTinysearch } from './{LOADER_FILE}';
+
         const searchInput = document.getElementById('searchInput');
-        searchInput.addEventListener('input', performSearch);
-        searchInput.addEventListener('keydown', function(event) {
-            if (event.key === 'Enter') {
-                performSearch();
+        const searchButton = document.getElementById('searchButton');
+        const status = document.getElementById('status');
+        const results = document.getElementById('results');
+        let engine;
+        let searchGeneration = 0;
+        let searchTimer = null;
+        const SEARCH_DEBOUNCE_MS = 60;
+
+        function setStatus(message, isError = false) {
+            status.textContent = message;
+            status.classList.toggle('error', isError);
+        }
+
+        function resultLink(url) {
+            try {
+                const resolved = new URL(url, document.baseURI);
+                if (resolved.protocol === 'http:' || resolved.protocol === 'https:') {
+                    return resolved.href;
+                }
+            } catch {
+                // The title is still useful when a corpus contains an invalid URL.
             }
-        });
-        
-        // Initialize search engine
-        searchInput.disabled = true;
-        initializeSearch();
+            return null;
+        }
+
+        function renderResults(items) {
+            const nodes = items.map((item) => {
+                const row = document.createElement('li');
+                row.className = 'result-item';
+                const href = resultLink(item.url);
+                if (href) {
+                    const link = document.createElement('a');
+                    link.className = 'result-title';
+                    link.href = href;
+                    link.target = '_blank';
+                    link.rel = 'noopener noreferrer';
+                    link.textContent = String(item.title ?? item.url);
+                    row.append(link);
+                } else {
+                    const title = document.createElement('span');
+                    title.className = 'result-title';
+                    title.textContent = String(item.title ?? item.url ?? 'Untitled result');
+                    row.append(title);
+                }
+                return row;
+            });
+            results.replaceChildren(...nodes);
+        }
+
+        async function runSearch(query, generation) {
+            try {
+                const items = await engine.search(query);
+                if (generation !== searchGeneration) {
+                    return;
+                }
+                renderResults(items);
+                const suffix = items.length === 1 ? '' : 's';
+                const stats = engine.stats;
+                const shardStatus = Number.isSafeInteger(stats.shardCount)
+                    ? ` ${stats.loadedShardCount} shard${stats.loadedShardCount === 1 ? '' : 's'} loaded.`
+                    : '';
+                setStatus(`${items.length} result${suffix} for “${query}”.${shardStatus}`);
+            } catch (error) {
+                if (generation !== searchGeneration) {
+                    return;
+                }
+                renderResults([]);
+                setStatus(`Search failed: ${error.message}`, true);
+                console.error(error);
+            }
+        }
+
+        function performSearch() {
+            const generation = ++searchGeneration;
+            if (searchTimer !== null) {
+                clearTimeout(searchTimer);
+                searchTimer = null;
+            }
+
+            const query = searchInput.value.trim();
+            if (!engine) {
+                setStatus('Search engine is not ready yet.');
+                return;
+            }
+            if (!query) {
+                renderResults([]);
+                setStatus('Enter a search query to see results.');
+                return;
+            }
+
+            setStatus(`Searching for “${query}”…`);
+            searchTimer = setTimeout(() => {
+                searchTimer = null;
+                void runSearch(query, generation);
+            }, SEARCH_DEBOUNCE_MS);
+        }
+
+        searchInput.addEventListener('input', performSearch);
+        searchButton.addEventListener('click', performSearch);
+
+        try {
+            engine = await initTinysearch();
+            searchInput.disabled = false;
+            searchButton.disabled = false;
+            setStatus('Search engine ready. Start typing to see results.');
+            searchInput.focus();
+        } catch (error) {
+            setStatus(`Failed to initialize search: ${error.message}`, true);
+            console.error(error);
+        }
     </script>
 </body>
 </html>

--- a/assets/legacy_tinysearch_loader.js
+++ b/assets/legacy_tinysearch_loader.js
@@ -1,0 +1,95 @@
+const DEFAULT_WASM_URL = new URL('./{WASM_FILE}', import.meta.url);
+
+class TinySearchWasm {
+    constructor(wasmInstance) {
+        this.wasm = wasmInstance;
+        this.memory = wasmInstance.exports.memory;
+        this.searchFn = wasmInstance.exports.search;
+        this.freeFn = wasmInstance.exports.free_search_result;
+        this.allocQueryFn = wasmInstance.exports.alloc_query;
+        this.freeQueryFn = wasmInstance.exports.free_query;
+        if (!this.searchFn || !this.freeFn || !this.allocQueryFn || !this.freeQueryFn) {
+            throw new Error('WASM module is missing required tinysearch exports');
+        }
+    }
+
+    stringToWasm(str) {
+        const bytes = new TextEncoder().encode(str + '\0');
+        const ptr = this.allocQueryFn(bytes.length);
+        if (ptr === 0) {
+            throw new Error(`WASM module could not allocate ${bytes.length} query bytes`);
+        }
+        const mem = new Uint8Array(this.memory.buffer, ptr, bytes.length);
+        mem.set(bytes);
+        return { ptr, len: bytes.length };
+    }
+
+    wasmToString(ptr) {
+        if (ptr === 0) return null;
+        const mem = new Uint8Array(this.memory.buffer);
+        let end = ptr;
+        while (end < mem.length && mem[end] !== 0) end += 1;
+        if (end === mem.length) {
+            throw new Error('WASM search result is missing its null terminator');
+        }
+        return new TextDecoder().decode(mem.subarray(ptr, end));
+    }
+
+
+    get stats() {
+        return { loadedShardCount: 0 };
+    }
+
+    async search(query, numResults = 5) {
+        const input = this.stringToWasm(query);
+        let resultPtr;
+        try {
+            resultPtr = this.searchFn(input.ptr, numResults);
+        } finally {
+            this.freeQueryFn(input.ptr, input.len);
+        }
+        if (resultPtr === 0) {
+            throw new Error('WASM search returned a null result pointer');
+        }
+
+        let jsonStr;
+        try {
+            jsonStr = this.wasmToString(resultPtr);
+        } finally {
+            this.freeFn(resultPtr);
+        }
+        try {
+            return JSON.parse(jsonStr);
+        } catch (error) {
+            throw new Error(`WASM search returned invalid JSON: ${error.message}`, { cause: error });
+        }
+    }
+}
+
+export async function initTinysearch(options = {}) {
+    const wasmUrl = new URL(options.wasmUrl ?? DEFAULT_WASM_URL, import.meta.url);
+    const fetchFn = options.fetch ?? globalThis.fetch?.bind(globalThis);
+    if (typeof fetchFn !== 'function') {
+        throw new Error('No fetch implementation is available; pass options.fetch');
+    }
+
+    const response = await fetchFn(wasmUrl);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch WASM module ${wasmUrl.href}: HTTP ${response.status}`);
+    }
+
+    if (typeof WebAssembly.instantiateStreaming === 'function') {
+        try {
+            const result = await WebAssembly.instantiateStreaming(response.clone(), {});
+            return new TinySearchWasm(result.instance ?? result);
+        } catch {
+            // Fall back when the server does not use application/wasm.
+        }
+    }
+
+    const result = await WebAssembly.instantiate(await response.arrayBuffer(), {});
+    return new TinySearchWasm(result.instance ?? result);
+}
+
+export const init_tinysearch = initTinysearch;
+export { TinySearchWasm as TinySearch };

--- a/assets/tinysearch_loader.js
+++ b/assets/tinysearch_loader.js
@@ -1,72 +1,445 @@
-class TinySearchWasm {
-    constructor(wasmInstance) {
-        this.wasm = wasmInstance;
-        this.memory = wasmInstance.exports.memory;
-        this.searchFn = wasmInstance.exports.search;
-        this.freeFn = wasmInstance.exports.free_search_result;
-    }
+const DEFAULT_WASM_URL = new URL('./{WASM_FILE}', import.meta.url);
+const DEFAULT_ROOT_URL = new URL('./{ROOT_FILE}', import.meta.url);
+const EXPECTED_ABI_VERSION = 1;
+const WASM_PAGE_BYTES = 64 * 1024;
 
-    // Convert JS string to WASM memory
-    stringToWasm(str) {
-        const bytes = new TextEncoder().encode(str + '\0');
-        const ptr = this.wasm.exports.malloc ? this.wasm.exports.malloc(bytes.length) : this.allocString(bytes.length);
-        const mem = new Uint8Array(this.memory.buffer, ptr, bytes.length);
-        mem.set(bytes);
-        return ptr;
-    }
-
-    // Read string from WASM memory
-    wasmToString(ptr) {
-        if (ptr === 0) return null;
-        const mem = new Uint8Array(this.memory.buffer);
-        let end = ptr;
-        while (mem[end] !== 0) end++;
-        return new TextDecoder().decode(mem.subarray(ptr, end));
-    }
-
-    // Simple string allocation fallback
-    allocString(len) {
-        // This is a simple fallback - WASM linear memory grows as needed
-        const pages = Math.ceil(len / 65536);
-        this.memory.grow(pages);
-        return this.memory.buffer.byteLength - len;
-    }
-
-    // Perform search
-    search(query, numResults = 5) {
-        const queryPtr = this.stringToWasm(query);
-        const resultPtr = this.searchFn(queryPtr, numResults);
-        
-        if (resultPtr === 0) {
-            return [];
-        }
-
-        const jsonStr = this.wasmToString(resultPtr);
-        this.freeFn(resultPtr);
-        
-        try {
-            return JSON.parse(jsonStr);
-        } catch (e) {
-            console.error('Failed to parse search results:', e);
-            return [];
-        }
-    }
+function asUrl(value, base = import.meta.url) {
+    return value instanceof URL ? new URL(value.href) : new URL(String(value), base);
 }
 
-export async function init_tinysearch() {
+function asDirectoryUrl(value, base) {
+    const url = asUrl(value, base);
+    if (!url.pathname.endsWith('/')) {
+        url.pathname += '/';
+    }
+    url.search = '';
+    url.hash = '';
+    return url;
+}
+
+function statusDescription(response) {
+    const text = response.statusText ? ` ${response.statusText}` : '';
+    return `${response.status}${text}`;
+}
+
+async function checkedFetch(fetchFn, url, kind) {
+    let response;
     try {
-        // Try streaming first (preferred)
-        const wasmModule = await WebAssembly.instantiateStreaming(fetch('./{WASM_FILE}'));
-        return new TinySearchWasm(wasmModule.instance);
-    } catch (e) {
-        console.warn('Streaming failed, falling back to fetch + instantiate:', e.message);
-        // Fallback for servers with wrong MIME type
-        const response = await fetch('./{WASM_FILE}');
-        const wasmBytes = await response.arrayBuffer();
-        const wasmModule = await WebAssembly.instantiate(wasmBytes);
-        return new TinySearchWasm(wasmModule.instance);
+        response = await fetchFn(url);
+    } catch (error) {
+        throw new TinySearchError(`Failed to fetch ${kind} ${url.href}: ${error.message}`, {
+            cause: error,
+            url: url.href,
+        });
+    }
+    if (!response || !response.ok) {
+        const status = response ? statusDescription(response) : 'no response';
+        throw new TinySearchError(`Failed to fetch ${kind} ${url.href}: HTTP ${status}`, {
+            url: url.href,
+            status: response?.status,
+        });
+    }
+    return response;
+}
+
+async function instantiateEngine(fetchFn, wasmUrl) {
+    const response = await checkedFetch(fetchFn, wasmUrl, 'WASM module');
+    let streamingError;
+
+    if (typeof WebAssembly.instantiateStreaming === 'function') {
+        try {
+            const result = await WebAssembly.instantiateStreaming(response.clone(), {});
+            return result.instance ?? result;
+        } catch (error) {
+            streamingError = error;
+        }
+    }
+
+    try {
+        const bytes = await response.arrayBuffer();
+        const result = await WebAssembly.instantiate(bytes, {});
+        return result.instance ?? result;
+    } catch (error) {
+        const streamingDetail = streamingError
+            ? ` Streaming instantiation failed: ${streamingError.message}.`
+            : '';
+        throw new TinySearchError(
+            `Failed to instantiate WASM module ${wasmUrl.href}.${streamingDetail} ` +
+                `ArrayBuffer fallback failed: ${error.message}`,
+            { cause: error, url: wasmUrl.href },
+        );
     }
 }
 
-// Backward compatibility
-export { TinySearchWasm as TinySearch };
+function requireEngineExports(instance) {
+    const required = [
+        'memory',
+        'engine_abi_version',
+        'engine_alloc',
+        'engine_dealloc',
+        'engine_load_root',
+        'engine_plan_query',
+        'engine_load_shard',
+        'engine_search',
+        'engine_result_ptr',
+        'engine_result_len',
+        'engine_result_free',
+    ];
+    const missing = required.filter((name) => instance.exports[name] === undefined);
+    if (missing.length > 0) {
+        throw new TinySearchError(`WASM module is missing required exports: ${missing.join(', ')}`);
+    }
+
+    const version = instance.exports.engine_abi_version() >>> 0;
+    if (version !== EXPECTED_ABI_VERSION) {
+        throw new TinySearchError(
+            `Unsupported tinysearch engine ABI ${version}; expected ${EXPECTED_ABI_VERSION}`,
+        );
+    }
+}
+
+/** Error raised for network, ABI, and structured engine failures. */
+export class TinySearchError extends Error {
+    constructor(message, details = {}) {
+        super(message, details.cause ? { cause: details.cause } : undefined);
+        this.name = 'TinySearchError';
+        Object.assign(this, details);
+    }
+}
+
+/** Async loader and client for a raw-WASM sharded tinysearch engine. */
+export class TinySearch {
+    constructor(instance, options) {
+        requireEngineExports(instance);
+        this.instance = instance;
+        this.exports = instance.exports;
+        this.memory = instance.exports.memory;
+        this.wasmUrl = options.wasmUrl;
+        this.rootUrl = options.rootUrl;
+        this.shardBaseUrl = options.shardBaseUrl;
+        this._fetch = options.fetch;
+        this._encoder = new TextEncoder();
+        this._decoder = new TextDecoder('utf-8', { fatal: true });
+        this._loadedUrls = new Set();
+        this._shardPromises = new Map();
+        this._requestCounts = options.requestCounts;
+        this._engineStats = {
+            shardCount: 0,
+            loadedShardCount: 0,
+            loadedShardBytes: 0,
+        };
+    }
+
+    /** URLs of lexical shards retained by the WASM engine. */
+    get loadedUrls() {
+        return [...this._loadedUrls];
+    }
+
+    /**
+     * A snapshot of loader, network, and WASM-memory statistics.
+     * `loadedShardBytes` is the sum of loaded artifacts' encoded lengths;
+     * `wasmMemoryBytes` reports the current linear-memory allocation.
+     */
+    get stats() {
+        return {
+            ...this._engineStats,
+            loadedUrls: this.loadedUrls,
+            inFlightShardCount: this._shardPromises.size,
+            wasmMemoryBytes: this.memory.buffer.byteLength,
+            wasmMemoryPages: this.memory.buffer.byteLength / WASM_PAGE_BYTES,
+            requests: Object.fromEntries(this._requestCounts),
+        };
+    }
+
+    _updateStats(response) {
+        for (const key of ['shardCount', 'loadedShardCount', 'loadedShardBytes']) {
+            if (Number.isSafeInteger(response[key])) {
+                this._engineStats[key] = response[key];
+            }
+        }
+    }
+
+    _readResponse(handle, operation) {
+        const resultHandle = handle >>> 0;
+        if (resultHandle === 0) {
+            throw new TinySearchError(`Engine ${operation} failed to allocate a response handle`);
+        }
+
+        try {
+            const ptr = this.exports.engine_result_ptr(resultHandle) >>> 0;
+            const len = this.exports.engine_result_len(resultHandle) >>> 0;
+            if (ptr === 0 || len === 0 || ptr + len > this.memory.buffer.byteLength) {
+                throw new TinySearchError(
+                    `Engine ${operation} returned an invalid response region ` +
+                        `(handle=${resultHandle}, ptr=${ptr}, len=${len})`,
+                );
+            }
+
+            // The result allocation may have grown memory, so construct the view only now.
+            const bytes = new Uint8Array(this.memory.buffer, ptr, len).slice();
+            let response;
+            try {
+                response = JSON.parse(this._decoder.decode(bytes));
+            } catch (error) {
+                throw new TinySearchError(`Engine ${operation} returned invalid UTF-8 JSON: ${error.message}`, {
+                    cause: error,
+                });
+            }
+            if (!response || typeof response !== 'object' || typeof response.ok !== 'boolean') {
+                throw new TinySearchError(`Engine ${operation} returned a malformed response object`);
+            }
+            this._updateStats(response);
+            if (!response.ok) {
+                const needs = Array.isArray(response.needs)
+                    ? ` (needs: ${response.needs.map((shard) => shard.filename ?? shard.id).join(', ')})`
+                    : '';
+                throw new TinySearchError(
+                    `Engine ${operation} failed${response.code ? ` [${response.code}]` : ''}: ` +
+                        `${response.error ?? 'unknown engine error'}${needs}`,
+                    { engine: response },
+                );
+            }
+            return response;
+        } finally {
+            this.exports.engine_result_free(resultHandle);
+        }
+    }
+
+    _invokeBytes(operation, bytes, ...args) {
+        const input = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+        const len = input.byteLength;
+        const ptr = len === 0 ? 0 : this.exports.engine_alloc(len) >>> 0;
+        if (len !== 0 && ptr === 0) {
+            throw new TinySearchError(`Engine ${operation} could not allocate ${len} input bytes`);
+        }
+
+        try {
+            // engine_alloc may grow memory, so never retain a view across allocation.
+            if (len !== 0) {
+                new Uint8Array(this.memory.buffer, ptr, len).set(input);
+            }
+            const handle = this.exports[operation](ptr, len, ...args);
+            return this._readResponse(handle, operation);
+        } finally {
+            if (len !== 0) {
+                this.exports.engine_dealloc(ptr, len);
+            }
+        }
+    }
+
+    _invokeQuery(operation, query, ...args) {
+        return this._invokeBytes(operation, this._encoder.encode(String(query)), ...args);
+    }
+
+    _descriptorWithUrl(descriptor) {
+        if (!descriptor || !Number.isSafeInteger(descriptor.id) || typeof descriptor.filename !== 'string') {
+            throw new TinySearchError('Engine query plan contains a malformed shard descriptor');
+        }
+        const url = new URL(descriptor.filename, this.shardBaseUrl);
+        return { id: descriptor.id, filename: descriptor.filename, url: url.href };
+    }
+
+    /** Returns the shard plan for `query` without performing network requests. */
+    plan(query) {
+        const response = this._invokeQuery('engine_plan_query', query);
+        if (!Array.isArray(response.required)) {
+            throw new TinySearchError('Engine query plan is missing its required shard list');
+        }
+        return {
+            ...response,
+            required: response.required.map((descriptor) => this._descriptorWithUrl(descriptor)),
+        };
+    }
+
+    async _fetchBytes(url, kind) {
+        const response = await checkedFetch(this._fetch, url, kind);
+        return new Uint8Array(await response.arrayBuffer());
+    }
+
+    async _ensureShard(descriptor) {
+        const url = asUrl(descriptor.url);
+        const key = url.href;
+        if (this._loadedUrls.has(key)) {
+            return;
+        }
+
+        const existing = this._shardPromises.get(key);
+        if (existing) {
+            return existing;
+        }
+
+        const promise = (async () => {
+            const bytes = await this._fetchBytes(url, `shard ${descriptor.id}`);
+            let response;
+            try {
+                response = this._invokeBytes('engine_load_shard', bytes);
+            } catch (error) {
+                throw new TinySearchError(
+                    `Failed to load shard ${descriptor.id} from ${key}: ${error.message}`,
+                    { cause: error, url: key, engine: error.engine },
+                );
+            }
+            if (response.id !== descriptor.id) {
+                throw new TinySearchError(
+                    `Shard ${key} loaded as engine ID ${response.id}, expected ${descriptor.id}`,
+                    { url: key },
+                );
+            }
+            this._loadedUrls.add(key);
+        })();
+
+        this._shardPromises.set(key, promise);
+        try {
+            await promise;
+        } finally {
+            // Failures must not become sticky; successful shards are covered by loadedUrls.
+            if (this._shardPromises.get(key) === promise) {
+                this._shardPromises.delete(key);
+            }
+        }
+    }
+
+    /** Fetches and loads the shards needed by `query` without running a search. */
+    async preload(query) {
+        const plan = this.plan(query);
+        await Promise.all(plan.required.map((descriptor) => this._ensureShard(descriptor)));
+        return {
+            ...plan,
+            loadedUrls: this.loadedUrls,
+        };
+    }
+
+    /** Lazily loads required shards, then returns stable `{title,url,meta}` results. */
+    async search(query, limit = 5) {
+        if (!Number.isInteger(limit) || limit < 0 || limit > 0xffff_ffff) {
+            throw new TypeError('search limit must be an integer between 0 and 4294967295');
+        }
+        await this.preload(query);
+        const response = this._invokeQuery('engine_search', query, limit);
+        if (!Array.isArray(response.results)) {
+            throw new TinySearchError('Engine search response is missing its results array');
+        }
+        return response.results.map((result) => ({
+            title: result.title,
+            url: result.url,
+            meta: result.meta,
+        }));
+    }
+
+    /**
+     * Attaches debounced, stale-safe async typeahead behavior to an input-like
+     * EventTarget. Planning and fetching begin only after `debounceMs` (60ms by
+     * default), and `render` is called only for the newest input generation.
+     * Requests that were already started are not canceled because they may be
+     * shared with another query; their completion is cached but never rendered
+     * when a newer input generation exists.
+     */
+    attachTypeahead(input, render, options = {}) {
+        if (!input || typeof input.addEventListener !== 'function') {
+            throw new TypeError('attachTypeahead requires an input-like EventTarget');
+        }
+        if (typeof render !== 'function') {
+            throw new TypeError('attachTypeahead requires a render function');
+        }
+
+        const limit = options.limit ?? 5;
+        const debounceMs = options.debounceMs ?? 60;
+        if (!Number.isFinite(debounceMs) || debounceMs < 0) {
+            throw new TypeError('typeahead debounceMs must be a non-negative finite number');
+        }
+
+        let generation = 0;
+        let debounceTimer = null;
+        const cancelDebounce = () => {
+            if (debounceTimer !== null) {
+                clearTimeout(debounceTimer);
+                debounceTimer = null;
+            }
+        };
+        const runSearch = async (current, query) => {
+            if (current !== generation) {
+                return;
+            }
+            try {
+                const results = await this.search(query, limit);
+                if (current === generation) {
+                    render(results, query);
+                    options.onStatus?.('ready', query, results);
+                }
+            } catch (error) {
+                if (current === generation) {
+                    options.onError?.(error, query);
+                    options.onStatus?.('error', query, error);
+                }
+            }
+        };
+        const onInput = () => {
+            const current = ++generation;
+            cancelDebounce();
+            const query = String(input.value ?? '').trim();
+            options.onStatus?.(query ? 'searching' : 'empty', query);
+            if (!query) {
+                render([], query);
+                return;
+            }
+
+            debounceTimer = setTimeout(() => {
+                debounceTimer = null;
+                void runSearch(current, query);
+            }, debounceMs);
+        };
+
+        input.addEventListener('input', onInput);
+        return () => {
+            generation += 1;
+            cancelDebounce();
+            input.removeEventListener('input', onInput);
+        };
+    }
+}
+
+/** Fetches, instantiates, and initializes a sharded tinysearch engine. */
+export async function initTinysearch(options = {}) {
+    const wasmUrl = asUrl(options.wasmUrl ?? DEFAULT_WASM_URL);
+    const rootUrl = asUrl(options.rootUrl ?? DEFAULT_ROOT_URL);
+    const shardBaseUrl = options.shardBaseUrl === undefined
+        ? new URL('.', rootUrl)
+        : asDirectoryUrl(options.shardBaseUrl, rootUrl);
+    const fetchFn = options.fetch ?? options.fetchFn ?? globalThis.fetch?.bind(globalThis);
+    if (typeof fetchFn !== 'function') {
+        throw new TinySearchError('No fetch implementation is available; pass options.fetch');
+    }
+
+    const requestCounts = new Map();
+    const trackedFetch = async (url) => {
+        const key = asUrl(url).href;
+        requestCounts.set(key, (requestCounts.get(key) ?? 0) + 1);
+        return fetchFn(url);
+    };
+
+    const instance = await instantiateEngine(trackedFetch, wasmUrl);
+    const engine = new TinySearch(instance, {
+        wasmUrl,
+        rootUrl,
+        shardBaseUrl,
+        fetch: trackedFetch,
+        requestCounts,
+    });
+    const rootResponse = await checkedFetch(trackedFetch, rootUrl, 'sharded root');
+    const rootBytes = new Uint8Array(await rootResponse.arrayBuffer());
+    try {
+        engine._updateStats(engine._invokeBytes('engine_load_root', rootBytes));
+    } catch (error) {
+        throw new TinySearchError(`Failed to load sharded root ${rootUrl.href}: ${error.message}`, {
+            cause: error,
+            url: rootUrl.href,
+            engine: error.engine,
+        });
+    }
+    return engine;
+}
+
+/** Compatibility alias for the loader's original snake_case initializer. */
+export const init_tinysearch = initTinysearch;
+
+export default initTinysearch;

--- a/docs/sharded-index.md
+++ b/docs/sharded-index.md
@@ -1,0 +1,224 @@
+# Sharded indexes
+
+TinySearch's exact backend can be emitted as a small root plus immutable lexical
+shards. The browser loads the root once, asks the WASM engine which shards a
+query needs, and fetches only those shards before searching.
+
+This design keeps network orchestration in JavaScript and compact decoding and
+ranking in WebAssembly.
+
+## Goals
+
+- Preserve the exact backend's existing ranking and prefix semantics.
+- Keep the WASM engine independent of corpus size.
+- Avoid downloading unrelated posting lists.
+- Make shard requests cacheable across deployments.
+- Deduplicate concurrent requests and allow failed requests to be retried.
+- Keep the monolithic exact v2 and legacy Xor8 formats readable.
+- Reject malformed, mismatched, or corrupt artifacts before searching them.
+
+## Artifact set
+
+An exact WASM build emits:
+
+```text
+tinysearch_engine.wasm
+tinysearch_engine.js
+tinysearch.root
+<sha256>.tinysearch-shard
+<sha256>.tinysearch-shard
+...
+```
+
+`tinysearch.root` contains:
+
+- the root format version;
+- result metadata (`PostId` records);
+- ordered lexical ranges;
+- each shard's numeric ID, byte length, SHA-256 digest, and filename.
+
+Each shard contains a contiguous range of normalized terms and their posting
+lists. Posting lists continue to use global dense document IDs with delta and
+varint encoding.
+
+The shard filename is the full lowercase SHA-256 digest of its encoded bytes.
+Unchanged shards therefore retain the same URL between builds. The CLI and
+high-level `TinySearch` API sort documents by URL, title, and metadata before
+assigning IDs, so their artifact generation is deterministic even when input
+arrived through a `HashMap`. Direct `ExactIndexBackend` callers retain their
+supplied document order, which controls equal-score ordering and artifact IDs.
+
+## Query lifecycle
+
+```mermaid
+flowchart TD
+    A[Load corpus-independent WASM] --> B[Load tinysearch.root]
+    B --> C[Plan normalized query in WASM]
+    C --> D{Required shards cached?}
+    D -->|No| E[Fetch missing content-addressed shards]
+    E --> F[Validate digest, ID, range, and postings]
+    F --> G[Merge decoded shard into WASM state]
+    D -->|Yes| H[Search loaded ranges]
+    G --> H
+    H --> I[Return title, URL, and metadata]
+```
+
+The loader stores one in-flight promise per shard URL. Concurrent searches that
+need the same shard share that request. Failed promises are removed so a later
+search can retry. Loaded shard URLs remain cached by the loader and decoded
+shards remain in WASM memory for the engine's lifetime.
+
+The engine does not retain a second copy of each encoded shard after decoding;
+it keeps only decoded terms/postings and the digest needed for idempotence.
+
+## Prefix routing
+
+Vocabulary ranges are sorted lexically.
+
+- Query terms shorter than `MIN_PREFIX_LEN` route to the single range that could
+  contain the exact term.
+- Longer query terms route to every range that can contain a completion of that
+  prefix.
+- Multi-term queries use the sorted, deduplicated union of those shard IDs.
+
+Routing is deliberately conservative at shard boundaries. It may fetch a shard
+whose lexical range contains a gap, but it cannot omit a possible completion.
+
+Search still applies the existing scoring model for every query-token
+occurrence:
+
+| Match | Score |
+| --- | ---: |
+| Exact title token | 3 |
+| Title prefix of at least three characters | 2 |
+| Any matching content completion | 1 |
+
+A document receives at most one content point per query token, even if several
+matching terms live in different shards. Multi-term queries remain additive OR
+queries, and equal scores retain global document order.
+
+## Building
+
+The default raw shard target is 64 KiB:
+
+```sh
+tinysearch --release -m wasm -p wasm_output index.json
+```
+
+Use `--shard-size` to tune the raw target:
+
+```sh
+tinysearch --release --shard-size 32768 -m wasm -p wasm_output index.json
+```
+
+Partitioning uses estimated encoded byte weight, not term count. A single term
+and its posting list are never split, so an oversized singleton shard may exceed
+the target.
+
+The CLI reports WASM, root, total shard, and maximum shard sizes after each
+build. Very small shard targets increase root descriptor size and HTTP request
+count; they exist mainly for stress testing. Start with 64 KiB and adjust using
+real compressed transfer and latency measurements.
+
+## JavaScript API
+
+```js
+import { initTinysearch } from './tinysearch_engine.js';
+
+const engine = await initTinysearch();
+const results = await engine.search('rust wasm', 10);
+```
+
+Custom deployment locations are supported:
+
+```js
+const engine = await initTinysearch({
+  wasmUrl: new URL('/search/tinysearch_engine.wasm', location.origin),
+  rootUrl: new URL('/search/tinysearch.root', location.origin),
+  shardBaseUrl: new URL('/search/', location.origin),
+});
+```
+
+The loader also exposes:
+
+- `plan(query)` to inspect required shards without fetching;
+- `preload(query)` to fetch and decode required shards;
+- `search(query, limit)` to preload and search;
+- `loadedUrls` and `stats` for observability;
+- `attachTypeahead(input, render, options)` for stale-safe async input handling.
+
+The loader resolves default asset URLs relative to its own ES module URL, uses
+`WebAssembly.instantiateStreaming` when possible, and falls back to
+`WebAssembly.instantiate` without downloading the WASM a second time.
+
+## WASM ABI
+
+The generated engine uses a small versioned raw ABI. Inputs are pointer/length
+pairs allocated through `engine_alloc` and released through `engine_dealloc`.
+Outputs use opaque handles with pointer, length, and free operations.
+
+This avoids null-terminated strings, guessed allocator exports, fixed scratch
+addresses, and the previous behavior of growing linear memory for every query.
+The integration suite performs hundreds of warmed searches and verifies that
+memory does not grow one page per request.
+
+## HTTP caching and deployment
+
+Recommended headers:
+
+- `tinysearch.root`: revalidate (`Cache-Control: no-cache`) or use a short TTL;
+- WASM and content-addressed shards: `Cache-Control: public, max-age=31536000, immutable`;
+- `tinysearch_engine.js`: version or content-address it in the surrounding site build.
+
+Upload new shards and WASM before publishing the new root. Retain old
+content-addressed shards long enough for clients that still hold an older root.
+Do not overwrite a content-addressed shard with different bytes.
+
+Serve the WASM as `application/wasm`. Shards and the root may use
+`application/octet-stream`. Standard HTTP Brotli or gzip compression is
+recommended.
+
+## Test strategy
+
+The feature has three layers of tests:
+
+1. Native differential tests compare monolithic and fully loaded sharded results
+   for every complete term, every Unicode-safe prefix, punctuation, short terms,
+   repeated terms, multi-term queries, and multiple result limits.
+2. Wire tests cover malformed roots/shards, IDs, lengths, digests, posting lists,
+   duplicates, and trailing bytes.
+3. The generated-artifact integration test compiles the actual WASM, imports the
+   emitted ES module under Node, injects a file-backed `fetch`, and verifies lazy
+   loading, strict-subset requests, request deduplication, retry behavior,
+   Unicode, result shape, MIME fallback, and bounded memory growth.
+
+## Initial fixture measurements
+
+Using `fixtures/index.json`, a release build with `wasm-opt -Oz`, and the
+default 64 KiB target:
+
+| Artifact | Raw | gzip -9 | Brotli 11 |
+| --- | ---: | ---: | ---: |
+| WASM engine | 100,623 B | 46,604 B | 39,400 B |
+| ES module loader | 16,364 B | 4,394 B | 3,808 B |
+| Root | 5,179 B | 2,376 B | 2,001 B |
+| Larger shard | 65,528 B | 35,787 B | 31,307 B |
+| Smaller shard | 12,003 B | 6,986 B | 6,026 B |
+
+The first query generally needs one shard, so the measured Brotli cold payload
+for a query routed to the larger shard is about 76.5 KiB rather than the complete
+index. In the Node integration run, 250 warmed searches averaged 0.065 ms each
+and added zero WASM memory bytes. These numbers are a baseline, not a permanent
+budget; changes should report the same measurements and investigate material
+regressions.
+
+## Current scope
+
+Query-selective sharding is implemented for the exact backend. Xor8 remains on
+its legacy embedded WASM path because its per-document filters must all be
+scanned for an arbitrary query and do not benefit from lexical routing.
+
+The current root keeps result metadata so searches can return complete results
+without a second metadata waterfall. If metadata becomes the dominant root cost
+for very large corpora, document-range metadata shards are the next compatible
+extension to the format.

--- a/src/api.rs
+++ b/src/api.rs
@@ -486,8 +486,7 @@ impl TinySearch {
         })
     }
 
-    /// Remove non-ascii characters from string
-    /// Keep apostrophe (e.g. for words like "don't")
+    /// Replaces non-letter punctuation with spaces while preserving apostrophes.
     fn cleanup(s: &str) -> String {
         s.replace(|c: char| !(c.is_alphabetic() || c == '\''), " ")
     }
@@ -517,7 +516,7 @@ impl TinySearch {
             })
             .collect();
 
-        split_posts
+        let mut documents: Vec<IndexedDocument> = split_posts
             .into_iter()
             .map(|(post_id, body)| {
                 let mut content = Self::tokenize_with_stopwords(&post_id.title, stopwords);
@@ -529,7 +528,15 @@ impl TinySearch {
                 }
                 IndexedDocument::new(post_id, content)
             })
-            .collect()
+            .collect();
+        documents.sort_by(|left, right| {
+            (&left.post.url, &left.post.title, &left.post.meta).cmp(&(
+                &right.post.url,
+                &right.post.title,
+                &right.post.meta,
+            ))
+        });
+        documents
     }
 
     /// Prepare posts for index generation (internal implementation)

--- a/src/bin/tinysearch.rs
+++ b/src/bin/tinysearch.rs
@@ -12,12 +12,13 @@ use utils::storage;
 use anyhow::{Context, bail};
 use anyhow::{Error, Result};
 use argh::FromArgs;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::str::FromStr;
 use std::{env, fs};
-use tempfile::TempDir;
-use tinysearch::{IndexKind, SearchSchema};
+use tempfile::{NamedTempFile, TempDir};
+use tinysearch::{IndexKind, SearchIndex, SearchSchema, ShardConfig};
 use toml_edit::{DocumentMut, value};
 
 use index::Posts;
@@ -75,6 +76,11 @@ fn default_engine_version() -> toml_edit::Table {
     dependency
 }
 
+fn parse_shard_config(input: &str) -> Result<ShardConfig, String> {
+    let target_bytes = input.parse::<usize>().map_err(|error| error.to_string())?;
+    ShardConfig::new(target_bytes).map_err(|error| error.to_string())
+}
+
 #[derive(FromArgs, Clone)]
 #[allow(clippy::struct_excessive_bools)]
 /// A tiny, static search engine for static websites
@@ -103,6 +109,15 @@ struct Opt {
     /// index backend used when creating storage (exact or xor8)
     #[argh(option, long = "indexer", default = "IndexKind::Exact")]
     index_kind: IndexKind,
+
+    /// raw target size in bytes for exact index shards (default: 65536)
+    #[argh(
+        option,
+        long = "shard-size",
+        from_str_fn(parse_shard_config),
+        default = "ShardConfig::default()"
+    )]
+    shard_config: ShardConfig,
 
     /// term to search in posts (only for search mode)
     #[argh(
@@ -167,7 +182,7 @@ struct Opt {
 trait Stage: Sized {
     fn from_opt(opt: &Opt) -> Result<Self, Error>;
 
-    fn build(&self) -> Result<(), Error>;
+    fn build(self) -> Result<(), Error>;
 }
 
 struct Search {
@@ -189,7 +204,7 @@ impl Stage for Search {
         })
     }
 
-    fn build(&self) -> Result<(), Error> {
+    fn build(self) -> Result<(), Error> {
         use tinysearch::{Storage, search as base_search};
         let bytes = fs::read(&self.storage_file).with_context(|| {
             format!("Failed to read input file: {}", self.storage_file.display())
@@ -211,42 +226,45 @@ impl Stage for Search {
 struct Storage {
     posts_index: PathBuf,
     out_path: PathBuf,
-    schema: SearchSchema,
+    index: SearchIndex,
     index_kind: IndexKind,
+}
+
+impl Storage {
+    fn into_index(self) -> SearchIndex {
+        self.index
+    }
 }
 
 impl Stage for Storage {
     fn from_opt(opt: &Opt) -> Result<Self, Error> {
         let posts_index = opt.input_file.clone().context("No input file")?;
-        let parent_dir = posts_index
-            .parent()
-            .unwrap_or_else(|| std::path::Path::new("."));
+        let parent_dir = posts_index.parent().unwrap_or_else(|| Path::new("."));
         let schema = SearchSchema::load_from_file(parent_dir)
             .map_err(|error| anyhow::anyhow!("Failed to load schema: {error}"))?;
+        let raw_content = fs::read_to_string(&posts_index)
+            .with_context(|| format!("Failed to read file {}", posts_index.display()))?;
+        let posts: Posts = index::read(&raw_content)
+            .with_context(|| format!("Failed to decode {}", posts_index.display()))?;
+        trace!("Generating storage from posts: {posts:#?}");
+        let search_index = storage::build(posts, &schema, opt.index_kind);
 
         Ok(Self {
             posts_index,
             out_path: ensure_exists(&opt.out_path)?,
-            schema,
+            index: search_index,
             index_kind: opt.index_kind,
         })
     }
 
-    fn build(&self) -> Result<(), Error> {
+    fn build(self) -> Result<(), Error> {
         let storage_file = self.out_path.join("storage");
         println!(
             "Creating storage file for posts {} in file {}",
             self.posts_index.display(),
             storage_file.display()
         );
-
-        let raw_content = fs::read_to_string(&self.posts_index)
-            .with_context(|| format!("Failed to read file {}", self.posts_index.display()))?;
-
-        let posts: Posts = index::read(&raw_content)
-            .with_context(|| format!("Failed to decode {}", self.posts_index.display()))?;
-        trace!("Generating storage from posts: {posts:#?}");
-        storage::write(posts, &storage_file, &self.schema, self.index_kind)?;
+        storage::write(self.index, &storage_file)?;
 
         println!("Storage ready in file {}", storage_file.display());
         Ok(())
@@ -259,30 +277,11 @@ struct Crate {
     name: String,
     engine_version: toml_edit::Table,
     non_top_level: bool,
+    shard_config: ShardConfig,
 }
 
-impl Stage for Crate {
-    fn from_opt(opt: &Opt) -> Result<Self, Error> {
-        if opt.crate_path.is_some() {
-            bail!("Don't use --crate-path to specify crate output dir!");
-        }
-        let out_path = ensure_exists(&opt.out_path)?;
-        let storage_opt = {
-            let mut ret: Opt = opt.clone();
-            ret.out_path = ensure_exists(&out_path.join("src"))?;
-            ret
-        };
-
-        Ok(Self {
-            s: Storage::from_opt(&storage_opt)?,
-            out_path,
-            name: opt.crate_name.clone(),
-            engine_version: opt.engine_version.clone(),
-            non_top_level: opt.non_top_level_crate,
-        })
-    }
-
-    fn build(&self) -> Result<(), Error> {
+impl Crate {
+    fn prepare(&self) -> Result<PathBuf, Error> {
         println!(
             "Creating tinysearch implementation crate {} in directory {}",
             self.name,
@@ -300,14 +299,84 @@ impl Stage for Crate {
             cargo_toml_contents["lib"] = toml_edit::table();
         }
         fs::write(cargo_toml, cargo_toml_contents.to_string())?;
+        ensure_exists(&self.out_path.join("src"))
+    }
 
-        self.s.build().context("Failed building storage")?;
-        fs::write(
-            self.out_path.join("src").join("lib.rs"),
-            assets::CRATE_LIB_RS,
-        )?;
+    fn build_embedded(self) -> Result<(), Error> {
+        let src_dir = self.prepare()?;
+        let index_dir = self.out_path.join("index");
+        if index_dir.try_exists()? {
+            fs::remove_dir_all(&index_dir).with_context(|| {
+                format!(
+                    "Failed removing sharded index directory {}",
+                    index_dir.display()
+                )
+            })?;
+        }
+
+        storage::write(self.s.into_index(), &src_dir.join("storage"))
+            .context("Failed building embedded storage")?;
+        fs::write(src_dir.join("lib.rs"), assets::CRATE_LIB_RS)?;
         println!("Crate content generated in {}/", self.out_path.display());
         Ok(())
+    }
+
+    fn build_sharded_exact(self) -> Result<storage::ShardedArtifacts, Error> {
+        if self.s.index_kind != IndexKind::Exact {
+            bail!("sharded crate generation requires the exact index backend");
+        }
+
+        let src_dir = self.prepare()?;
+        let storage_file = src_dir.join("storage");
+        if storage_file.try_exists()? {
+            fs::remove_file(&storage_file).with_context(|| {
+                format!(
+                    "Failed to remove legacy embedded storage {}",
+                    storage_file.display()
+                )
+            })?;
+        }
+        fs::write(src_dir.join("lib.rs"), assets::SHARDED_CRATE_LIB_RS)?;
+        let artifacts = storage::write_sharded(
+            &self.s.into_index(),
+            &self.out_path.join("index"),
+            self.shard_config,
+        )
+        .context("Failed building sharded index artifacts")?;
+        println!("Crate content generated in {}/", self.out_path.display());
+        Ok(artifacts)
+    }
+
+    fn build_for_wasm(self) -> Result<Option<storage::ShardedArtifacts>, Error> {
+        match self.s.index_kind {
+            IndexKind::Exact => self.build_sharded_exact().map(Some),
+            IndexKind::Xor8 => {
+                self.build_embedded()?;
+                Ok(None)
+            }
+        }
+    }
+}
+
+impl Stage for Crate {
+    fn from_opt(opt: &Opt) -> Result<Self, Error> {
+        if opt.crate_path.is_some() {
+            bail!("Don't use --crate-path to specify crate output dir!");
+        }
+        let out_path = ensure_exists(&opt.out_path)?;
+
+        Ok(Self {
+            s: Storage::from_opt(opt)?,
+            out_path,
+            name: opt.crate_name.clone(),
+            engine_version: opt.engine_version.clone(),
+            non_top_level: opt.non_top_level_crate,
+            shard_config: opt.shard_config,
+        })
+    }
+
+    fn build(self) -> Result<(), Error> {
+        self.build_embedded()
     }
 }
 
@@ -348,14 +417,13 @@ impl Stage for Wasm {
         })
     }
 
-    fn build(&self) -> Result<(), Error> {
-        self.c.build().context("Failed generating crate")?;
-        println!("Compiling WASM module using vanilla cargo build");
+    fn build(self) -> Result<(), Error> {
         let crate_path = self.crate_path.path();
         let wasm_name = self.c.name.replace('-', "_");
+        let artifacts = self.c.build_for_wasm().context("Failed generating crate")?;
+        println!("Compiling WASM module using vanilla cargo build");
 
-        // Build with vanilla cargo
-        run_output(
+        run_command(
             Command::new("cargo")
                 .current_dir(&crate_path)
                 .arg("build")
@@ -364,66 +432,230 @@ impl Stage for Wasm {
                 .arg("--release"),
         )?;
 
-        // Copy the WASM file to output directory
         let wasm_file = format!("{wasm_name}.wasm");
         let source_wasm = crate_path
             .join("target/wasm32-unknown-unknown/release")
             .join(&wasm_file);
         let dest_wasm = self.out_path.join(&wasm_file);
-        fs::copy(&source_wasm, &dest_wasm).with_context(|| {
-            format!(
-                "Failed to copy {} to {}",
-                source_wasm.display(),
-                dest_wasm.display()
-            )
-        })?;
 
-        // Generate simple JS loader
-        let js_content = assets::JS_LOADER.replace("{WASM_FILE}", &wasm_file);
-
-        let js_path = self.out_path.join(format!("{wasm_name}.js"));
-        if !self.release {
-            fs::write(&js_path, js_content)
-                .with_context(|| format!("Failed writing JS loader to {}", js_path.display()))?;
+        if let Some(sharded) = &artifacts {
+            let source_index = crate_path.join("index");
+            for filename in &sharded.shard_files {
+                copy_content_addressed_file(
+                    &source_index.join(filename),
+                    &self.out_path.join(filename),
+                )?;
+            }
         }
 
-        // Optional optimization
-        if self.optimize {
-            if run_output(
+        let wasm_temp = copy_to_temporary(&source_wasm, &self.out_path)?;
+        let wasm_temp = if self.optimize {
+            let optimized = NamedTempFile::new_in(&self.out_path)
+                .context("Failed creating temporary optimized WASM file")?;
+            if run_command(
                 Command::new("wasm-opt")
                     .current_dir(&self.out_path)
                     .arg("--enable-bulk-memory")
                     .arg("-Oz")
                     .arg("-o")
-                    .arg(&wasm_file)
-                    .arg(&wasm_file),
+                    .arg(optimized.path())
+                    .arg(wasm_temp.path()),
             )
             .is_ok()
             {
+                optimized.as_file().sync_all()?;
                 println!("Optimized WASM with wasm-opt");
+                optimized
             } else {
                 println!("wasm-opt unavailable or failed, skipping optimization");
+                wasm_temp
             }
+        } else {
+            wasm_temp
+        };
+        let wasm_bytes = fs::metadata(wasm_temp.path())?.len();
+        persist_replace(wasm_temp, &dest_wasm)?;
+
+        let loader_template = if artifacts.is_some() {
+            assets::JS_LOADER
+        } else {
+            assets::LEGACY_JS_LOADER
+        };
+        let js_content = loader_template
+            .replace("{WASM_FILE}", &wasm_file)
+            .replace("{ROOT_FILE}", storage::ROOT_FILENAME);
+        let loader_file = format!("{wasm_name}.js");
+        let js_path = self.out_path.join(&loader_file);
+        write_atomically(&js_path, js_content.as_bytes())?;
+
+        let html_path = self.out_path.join("demo.html");
+        if self.release {
+            if html_path.try_exists()? {
+                fs::remove_file(&html_path).with_context(|| {
+                    format!("Failed removing development demo {}", html_path.display())
+                })?;
+            }
+        } else {
+            let demo_html = assets::DEMO_HTML.replace("{LOADER_FILE}", &loader_file);
+            write_atomically(&html_path, demo_html.as_bytes())?;
+        }
+
+        if let Some(sharded) = &artifacts {
+            copy_file_atomically(
+                &crate_path.join("index").join(storage::ROOT_FILENAME),
+                &self.out_path.join(storage::ROOT_FILENAME),
+            )?;
+            print_wasm_artifact_sizes(wasm_bytes, sharded);
+        } else {
+            remove_stale_root(&self.out_path)?;
+            println!("Artifact sizes:");
+            println!("  WASM: {wasm_bytes} bytes");
         }
 
         if self.release {
             println!("Created production-ready WASM module");
-            println!("See docs for usage instructions");
-            println!("Path: {}", dest_wasm.display());
-            println!("Size: {} bytes", dest_wasm.metadata()?.len());
+            println!("WASM module at: {}", dest_wasm.display());
+            println!("JS loader at: {}", js_path.display());
         } else {
-            let html_path = self.out_path.join("demo.html");
-            fs::write(
-                &html_path,
-                assets::DEMO_HTML.replace("{WASM_NAME}", &wasm_name),
-            )
-            .with_context(|| format!("Failed writing demo.html to {}", html_path.display()))?;
             println!("All done! WASM module at: {}", dest_wasm.display());
             println!("JS loader at: {}", js_path.display());
             println!("Demo at: {}", html_path.display());
         }
         Ok(())
     }
+}
+
+fn copy_to_temporary(source: &Path, directory: &Path) -> Result<NamedTempFile, Error> {
+    let mut source_file = fs::File::open(source)
+        .with_context(|| format!("Failed opening source artifact {}", source.display()))?;
+    let mut temporary = NamedTempFile::new_in(directory).with_context(|| {
+        format!(
+            "Failed creating temporary artifact in {}",
+            directory.display()
+        )
+    })?;
+    io::copy(&mut source_file, temporary.as_file_mut())
+        .with_context(|| format!("Failed copying source artifact {}", source.display()))?;
+    temporary.as_file().sync_all()?;
+    Ok(temporary)
+}
+
+fn persist_replace(temporary: NamedTempFile, destination: &Path) -> Result<(), Error> {
+    temporary
+        .persist(destination)
+        .map_err(|error| error.error)
+        .with_context(|| {
+            format!(
+                "Failed atomically publishing artifact {}",
+                destination.display()
+            )
+        })?;
+    Ok(())
+}
+
+fn copy_file_atomically(source: &Path, destination: &Path) -> Result<(), Error> {
+    let directory = destination.parent().with_context(|| {
+        format!(
+            "Artifact destination has no parent directory: {}",
+            destination.display()
+        )
+    })?;
+    persist_replace(copy_to_temporary(source, directory)?, destination)
+}
+
+fn verify_content_addressed_file(source: &Path, destination: &Path) -> Result<(), Error> {
+    let source_bytes = fs::read(source)
+        .with_context(|| format!("Failed reading source shard {}", source.display()))?;
+    let destination_bytes = fs::read(destination).with_context(|| {
+        format!(
+            "Failed reading existing immutable shard {}",
+            destination.display()
+        )
+    })?;
+    if source_bytes != destination_bytes {
+        bail!(
+            "existing content-addressed shard has different bytes: {}",
+            destination.display()
+        );
+    }
+    Ok(())
+}
+
+fn copy_content_addressed_file(source: &Path, destination: &Path) -> Result<(), Error> {
+    if !destination
+        .file_name()
+        .is_some_and(|name| name.to_string_lossy().ends_with(storage::SHARD_FILE_SUFFIX))
+    {
+        bail!(
+            "refusing to publish non-shard content-addressed artifact {}",
+            destination.display()
+        );
+    }
+    if destination.try_exists()? {
+        return verify_content_addressed_file(source, destination);
+    }
+    let directory = destination.parent().with_context(|| {
+        format!(
+            "Shard destination has no parent directory: {}",
+            destination.display()
+        )
+    })?;
+    let temporary = copy_to_temporary(source, directory)?;
+    match temporary.persist_noclobber(destination) {
+        Ok(_file) => Ok(()),
+        Err(error) if error.error.kind() == io::ErrorKind::AlreadyExists => {
+            verify_content_addressed_file(source, destination)
+        }
+        Err(error) => Err(error.error).with_context(|| {
+            format!(
+                "Failed atomically publishing shard {}",
+                destination.display()
+            )
+        }),
+    }
+}
+
+fn write_atomically(destination: &Path, contents: &[u8]) -> Result<(), Error> {
+    let directory = destination.parent().with_context(|| {
+        format!(
+            "Artifact destination has no parent directory: {}",
+            destination.display()
+        )
+    })?;
+    let mut temporary = NamedTempFile::new_in(directory).with_context(|| {
+        format!(
+            "Failed creating temporary artifact in {}",
+            directory.display()
+        )
+    })?;
+    temporary.write_all(contents)?;
+    temporary.as_file().sync_all()?;
+    persist_replace(temporary, destination)
+}
+
+fn remove_stale_root(directory: &Path) -> Result<(), Error> {
+    let root_path = directory.join(storage::ROOT_FILENAME);
+    if root_path.try_exists()? {
+        fs::remove_file(&root_path).with_context(|| {
+            format!(
+                "Failed removing stale root artifact {}",
+                root_path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn print_wasm_artifact_sizes(wasm_bytes: u64, artifacts: &storage::ShardedArtifacts) {
+    println!("Artifact sizes:");
+    println!("  WASM: {wasm_bytes} bytes");
+    println!("  root: {} bytes", artifacts.root_bytes);
+    println!(
+        "  shards: {} files, {} bytes total, {} bytes max",
+        artifacts.shard_files.len(),
+        artifacts.total_shard_bytes,
+        artifacts.max_shard_bytes
+    );
 }
 
 /// Runs tinysearch using command-line arguments.
@@ -461,20 +693,38 @@ fn main() -> Result<(), Error> {
     })
 }
 
-/// Runs a child process and returns its standard output.
+/// Runs a child process and checks that it exits successfully.
 ///
 /// # Errors
 ///
 /// Returns an error if the process cannot be started or exits unsuccessfully.
-fn run_output(cmd: &mut Command) -> Result<String, Error> {
+fn run_command(cmd: &mut Command) -> Result<(), Error> {
     println!("running {cmd:?}");
-    let output = cmd
-        .stderr(Stdio::inherit())
-        .output()
+    let status = cmd
+        .status()
         .with_context(|| format!("failed to run {cmd:?}"))?;
 
-    if !output.status.success() {
-        anyhow::bail!("failed to execute {:?}\nstatus: {}", cmd, output.status)
+    if !status.success() {
+        anyhow::bail!("failed to execute {cmd:?}\nstatus: {status}")
     }
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    Ok(())
+}
+
+#[cfg(test)]
+mod publication_tests {
+    use super::*;
+
+    #[test]
+    fn refuses_to_reuse_a_content_address_with_different_bytes() -> Result<(), Error> {
+        let directory = TempDir::new()?;
+        let filename = format!("{}{}", "a".repeat(64), storage::SHARD_FILE_SUFFIX);
+        let source = directory.path().join("source");
+        let destination = directory.path().join(filename);
+        fs::write(&source, b"new shard bytes")?;
+        fs::write(&destination, b"different existing bytes")?;
+
+        assert!(copy_content_addressed_file(&source, &destination).is_err());
+        assert_eq!(fs::read(destination)?, b"different existing bytes");
+        Ok(())
+    }
 }

--- a/src/bin/utils/assets.rs
+++ b/src/bin/utils/assets.rs
@@ -6,6 +6,10 @@ pub static CRATE_LIB_RS: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/assets/crate/src/lib.rs"
 ));
+pub static SHARDED_CRATE_LIB_RS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/assets/crate/src/sharded_lib.rs"
+));
 
 // Include a bare-bones HTML page template that demonstrates how tinysearch is used
 pub static DEMO_HTML: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/demo.html"));
@@ -16,4 +20,8 @@ pub static STOP_WORDS: &str =
 pub static JS_LOADER: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/assets/tinysearch_loader.js"
+));
+pub static LEGACY_JS_LOADER: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/assets/legacy_tinysearch_loader.js"
 ));

--- a/src/bin/utils/storage.rs
+++ b/src/bin/utils/storage.rs
@@ -1,20 +1,26 @@
 use anyhow::Error;
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path;
+use std::path::Path;
 
 use super::assets::STOP_WORDS;
 use super::index::Posts;
 use strip_markdown::strip_markdown;
-use tinysearch::{IndexKind, IndexedDocument, PostId, SearchIndex, SearchSchema, Storage};
+use tinysearch::{
+    IndexKind, IndexedDocument, PostId, SearchIndex, SearchSchema, ShardConfig, Storage,
+};
 
-pub fn write(
-    posts: Posts,
-    path: &path::PathBuf,
-    schema: &SearchSchema,
-    index_kind: IndexKind,
-) -> Result<(), Error> {
-    let index = build(posts, schema, index_kind);
+pub const ROOT_FILENAME: &str = "tinysearch.root";
+pub const SHARD_FILE_SUFFIX: &str = ".tinysearch-shard";
+
+pub struct ShardedArtifacts {
+    pub root_bytes: usize,
+    pub shard_files: Vec<String>,
+    pub total_shard_bytes: usize,
+    pub max_shard_bytes: usize,
+}
+
+pub fn write(index: SearchIndex, path: &Path) -> Result<(), Error> {
     trace!("Storage::from");
     let storage = Storage::from(index);
     trace!("Write");
@@ -23,13 +29,47 @@ pub fn write(
     Ok(())
 }
 
-fn build(posts: Posts, schema: &SearchSchema, index_kind: IndexKind) -> SearchIndex {
+pub fn write_sharded(
+    index: &SearchIndex,
+    directory: &Path,
+    config: ShardConfig,
+) -> Result<ShardedArtifacts, Error> {
+    if directory.try_exists()? {
+        fs::remove_dir_all(directory)?;
+    }
+    fs::create_dir_all(directory)?;
+
+    let bundle = index.to_sharded_bundle(config)?;
+    let (root_bytes, shards) = bundle.into_parts();
+    let root_size = root_bytes.len();
+    fs::write(directory.join(ROOT_FILENAME), root_bytes)?;
+
+    let mut shard_files = Vec::with_capacity(shards.len());
+    let mut total_shard_bytes = 0_usize;
+    let mut max_shard_bytes = 0_usize;
+    for artifact in shards {
+        let (descriptor, bytes) = artifact.into_parts();
+        let shard_size = bytes.len();
+        fs::write(directory.join(&descriptor.filename), bytes)?;
+        total_shard_bytes = total_shard_bytes.saturating_add(shard_size);
+        max_shard_bytes = max_shard_bytes.max(shard_size);
+        shard_files.push(descriptor.filename);
+    }
+
+    Ok(ShardedArtifacts {
+        root_bytes: root_size,
+        shard_files,
+        total_shard_bytes,
+        max_shard_bytes,
+    })
+}
+
+pub fn build(posts: Posts, schema: &SearchSchema, index_kind: IndexKind) -> SearchIndex {
     let posts = prepare_posts(posts, schema);
     generate_index(posts, index_kind)
 }
 
-/// Remove non-ascii characters from string
-/// Keep apostrophe (e.g. for words like "don't")
+/// Replaces non-letter punctuation with spaces while preserving apostrophes.
 fn cleanup(s: &str) -> String {
     s.replace(|c: char| !(c.is_alphabetic() || c == '\''), " ")
 }
@@ -60,7 +100,7 @@ pub fn generate_index(
         })
         .collect();
 
-    let documents: Vec<IndexedDocument> = split_posts
+    let mut documents: Vec<IndexedDocument> = split_posts
         .into_iter()
         .map(|(post_id, body)| {
             let mut content = tokenize(&post_id.title, &stopwords);
@@ -73,6 +113,13 @@ pub fn generate_index(
             IndexedDocument::new(post_id, content)
         })
         .collect();
+    documents.sort_by(|left, right| {
+        (&left.post.url, &left.post.title, &left.post.meta).cmp(&(
+            &right.post.url,
+            &right.post.title,
+            &right.post.meta,
+        ))
+    });
     trace!("Done");
     index_kind.backend().build(documents)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 //! ```
 
 pub mod api;
+pub mod sharded;
 
 use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
@@ -280,6 +281,19 @@ impl SearchIndex {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Converts an exact index into a root and content-addressed lexical shards.
+    ///
+    /// Existing monolithic serialization is unchanged. Shard posting lists keep
+    /// the exact index's global dense document identifiers.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ShardError::UnsupportedBackend`] for Xor8 indexes, or a
+    /// validation or encoding error if the exact index cannot be sharded.
+    pub fn to_sharded_bundle(&self, config: ShardConfig) -> Result<ShardedIndexBundle, ShardError> {
+        sharded::build_bundle(self, config)
+    }
 }
 
 impl From<Vec<PostFilter>> for SearchIndex {
@@ -304,6 +318,10 @@ impl Default for SearchIndex {
 
 // Re-export public API types from the API module
 pub use api::{BasicPost, Post, TinySearch};
+pub use sharded::{
+    ShardArtifact, ShardConfig, ShardDescriptor, ShardError, ShardId, ShardedIndex,
+    ShardedIndexBundle,
+};
 
 /// Configuration schema for tinysearch.toml
 #[cfg(feature = "bin")]
@@ -865,39 +883,50 @@ fn title_term_score(title_terms: &[String], search_term: &str) -> usize {
     }
 }
 
+fn title_scores(posts: &[PostId], search_terms: &[String]) -> Vec<usize> {
+    let title_terms: Vec<Vec<String>> = posts.iter().map(|post| tokenize(&post.title)).collect();
+    let mut scores = vec![0_usize; posts.len()];
+    for search_term in search_terms {
+        for (score, terms) in scores.iter_mut().zip(&title_terms) {
+            *score = score.saturating_add(title_term_score(terms, search_term));
+        }
+    }
+    scores
+}
+
+fn matching_term_range(terms: &[String], search_term: &str) -> std::ops::Range<usize> {
+    let start = terms.partition_point(|term| term.as_str() < search_term);
+    let Some(candidates) = terms.get(start..) else {
+        return start..start;
+    };
+    let matching_count = if search_term.chars().count() >= MIN_PREFIX_LEN {
+        candidates
+            .iter()
+            .take_while(|term| term.starts_with(search_term))
+            .count()
+    } else {
+        usize::from(candidates.first().is_some_and(|term| term == search_term))
+    };
+    start..start.saturating_add(matching_count)
+}
+
 fn search_exact<'index>(
     index: &'index ExactIndex,
     search_terms: &[String],
     num_results: usize,
 ) -> Vec<&'index PostId> {
-    let title_terms: Vec<Vec<String>> = index
-        .posts
-        .iter()
-        .map(|post| tokenize(&post.title))
-        .collect();
-    let mut scores = vec![0_usize; index.posts.len()];
+    let mut scores = title_scores(&index.posts, search_terms);
     let mut content_matches = vec![false; index.posts.len()];
 
     for search_term in search_terms {
-        for (score, terms) in scores.iter_mut().zip(&title_terms) {
-            *score = score.saturating_add(title_term_score(terms, search_term));
-        }
-
         content_matches.fill(false);
-        let start = index
-            .terms
-            .partition_point(|term| term.as_str() < search_term.as_str());
-        let candidates = index.terms.get(start..).unwrap_or(&[]);
-        let matching_terms = if search_term.chars().count() >= MIN_PREFIX_LEN {
-            candidates
-                .iter()
-                .take_while(|term| term.starts_with(search_term))
-                .count()
-        } else {
-            usize::from(candidates.first().is_some_and(|term| term == search_term))
-        };
-
-        for postings in index.postings.iter().skip(start).take(matching_terms) {
+        let matching_terms = matching_term_range(&index.terms, search_term);
+        for postings in index
+            .postings
+            .iter()
+            .skip(matching_terms.start)
+            .take(matching_terms.len())
+        {
             for &document in postings {
                 if let Some(content_match) = content_matches.get_mut(document) {
                     *content_match = true;

--- a/src/sharded.rs
+++ b/src/sharded.rs
@@ -1,0 +1,1052 @@
+//! Sharded exact-index storage and incremental search.
+
+use crate::{
+    ExactIndex, MIN_PREFIX_LEN, PostId, SearchIndex, SearchIndexData, matching_term_range,
+    ranked_posts, title_scores, tokenize,
+};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+
+const ROOT_MAGIC: &[u8] = b"tinysearch-sharded-root";
+const SHARD_MAGIC: &[u8] = b"tinysearch-shard";
+const ROOT_VERSION: u8 = 1;
+const SHARD_VERSION: u8 = 1;
+const DIGEST_LEN: usize = 32;
+// Conservative lower bounds used before allocating from untrusted counts:
+// ID + two one-byte strings + length + digest + filename length; and
+// term length + one-byte term + posting count + first document ID.
+const MINIMUM_DESCRIPTOR_BYTES: usize = 39;
+const MINIMUM_TERM_BYTES: usize = 4;
+const DEFAULT_TARGET_BYTES: usize = 64 * 1024;
+const SHARD_FILE_SUFFIX: &str = ".tinysearch-shard";
+
+/// Configuration for partitioning an exact index into lexical shards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShardConfig {
+    target_bytes: usize,
+}
+
+impl ShardConfig {
+    /// Creates a configuration with the requested encoded raw-byte target.
+    ///
+    /// A single term and its posting list are kept together, so an oversized
+    /// term may produce a shard larger than this target.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ShardError::InvalidTargetBytes`] when `target_bytes` is zero.
+    pub const fn new(target_bytes: usize) -> Result<Self, ShardError> {
+        if target_bytes == 0 {
+            Err(ShardError::InvalidTargetBytes)
+        } else {
+            Ok(Self { target_bytes })
+        }
+    }
+
+    /// Returns the encoded raw-byte target for each lexical shard.
+    #[must_use]
+    pub const fn target_bytes(self) -> usize {
+        self.target_bytes
+    }
+}
+
+impl Default for ShardConfig {
+    fn default() -> Self {
+        Self {
+            target_bytes: DEFAULT_TARGET_BYTES,
+        }
+    }
+}
+
+impl TryFrom<usize> for ShardConfig {
+    type Error = ShardError;
+
+    fn try_from(target_bytes: usize) -> Result<Self, Self::Error> {
+        Self::new(target_bytes)
+    }
+}
+
+/// Stable numeric identifier for one lexical shard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ShardId(u32);
+
+impl ShardId {
+    /// Creates a shard identifier from its numeric value.
+    #[must_use]
+    pub const fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Returns the numeric value of this identifier.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for ShardId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Root metadata describing one immutable lexical shard artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShardDescriptor {
+    /// Contiguous numeric shard identifier.
+    pub id: ShardId,
+    /// First normalized term contained in the shard.
+    pub first_term: String,
+    /// Last normalized term contained in the shard.
+    pub last_term: String,
+    /// Content-addressed artifact filename.
+    pub filename: String,
+    /// Exact encoded artifact length in bytes.
+    pub encoded_len: usize,
+    /// SHA-256 digest of the encoded artifact.
+    pub digest: [u8; DIGEST_LEN],
+}
+
+impl ShardDescriptor {
+    /// Returns the lowercase hexadecimal SHA-256 digest.
+    #[must_use]
+    pub fn digest_hex(&self) -> String {
+        digest_hex(&self.digest)
+    }
+}
+
+/// Encoded bytes for one immutable lexical shard and their descriptor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShardArtifact {
+    descriptor: ShardDescriptor,
+    bytes: Vec<u8>,
+}
+
+impl ShardArtifact {
+    /// Returns the root descriptor for this artifact.
+    #[must_use]
+    pub const fn descriptor(&self) -> &ShardDescriptor {
+        &self.descriptor
+    }
+
+    /// Returns the encoded shard bytes.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Splits the artifact into its descriptor and encoded bytes.
+    #[must_use]
+    pub fn into_parts(self) -> (ShardDescriptor, Vec<u8>) {
+        (self.descriptor, self.bytes)
+    }
+}
+
+/// A root index and all content-addressed lexical shard artifacts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShardedIndexBundle {
+    root_bytes: Vec<u8>,
+    shards: Vec<ShardArtifact>,
+}
+
+impl ShardedIndexBundle {
+    /// Returns the encoded root bytes.
+    #[must_use]
+    pub fn root_bytes(&self) -> &[u8] {
+        &self.root_bytes
+    }
+
+    /// Returns the lexical shard artifacts in identifier order.
+    #[must_use]
+    pub fn shards(&self) -> &[ShardArtifact] {
+        &self.shards
+    }
+
+    /// Splits this bundle into its root bytes and lexical artifacts.
+    #[must_use]
+    pub fn into_parts(self) -> (Vec<u8>, Vec<ShardArtifact>) {
+        (self.root_bytes, self.shards)
+    }
+}
+
+/// Error produced while building, decoding, loading, or searching a sharded index.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ShardError {
+    /// A shard target of zero bytes is invalid.
+    InvalidTargetBytes,
+    /// Only the exact backend can be converted to lexical shards.
+    UnsupportedBackend,
+
+    /// The root envelope or its descriptors are malformed.
+    MalformedRoot(&'static str),
+    /// A shard envelope, vocabulary, or posting list is malformed.
+    MalformedShard(&'static str),
+    /// The artifact length differs from the root descriptor.
+    LengthMismatch {
+        /// Shard whose length did not match.
+        id: ShardId,
+        /// Length declared by the root.
+        expected: usize,
+        /// Length of the supplied artifact.
+        actual: usize,
+    },
+    /// The artifact digest differs from the root descriptor.
+    DigestMismatch {
+        /// Shard whose digest did not match.
+        id: ShardId,
+    },
+    /// The shard envelope contains an identifier different from its descriptor.
+    WrongShardId {
+        /// Identifier declared by the root descriptor.
+        expected: ShardId,
+        /// Identifier encoded in the shard envelope.
+        actual: ShardId,
+    },
+    /// The supplied artifact does not belong to this root index.
+    UnknownShard(ShardId),
+    /// Different bytes were supplied for a shard that is already loaded.
+    ConflictingShard(ShardId),
+    /// A query cannot run until the listed lexical shards are loaded.
+    NeedsShards(Vec<ShardId>),
+}
+
+impl std::fmt::Display for ShardError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidTargetBytes => {
+                formatter.write_str("shard target must be greater than zero")
+            }
+            Self::UnsupportedBackend => formatter.write_str("sharding requires the exact backend"),
+            Self::MalformedRoot(reason) => write!(formatter, "malformed sharded root: {reason}"),
+            Self::MalformedShard(reason) => write!(formatter, "malformed lexical shard: {reason}"),
+            Self::LengthMismatch {
+                id,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "shard {id} has length {actual}, expected {expected}"
+            ),
+            Self::DigestMismatch { id } => write!(formatter, "shard {id} digest does not match"),
+            Self::WrongShardId { expected, actual } => write!(
+                formatter,
+                "shard envelope has id {actual}, expected {expected}"
+            ),
+            Self::UnknownShard(id) => write!(formatter, "shard {id} does not belong to this root"),
+            Self::ConflictingShard(id) => {
+                write!(
+                    formatter,
+                    "different bytes are already loaded for shard {id}"
+                )
+            }
+            Self::NeedsShards(ids) => write!(formatter, "query needs unloaded shards {ids:?}"),
+        }
+    }
+}
+
+impl std::error::Error for ShardError {}
+
+#[derive(Debug)]
+struct LoadedShard {
+    terms: Vec<String>,
+    postings: Vec<Vec<usize>>,
+    digest: [u8; DIGEST_LEN],
+}
+
+/// An exact index whose root is available immediately and whose lexical shards
+/// can be loaded incrementally.
+#[derive(Debug)]
+pub struct ShardedIndex {
+    posts: Vec<PostId>,
+    descriptors: Vec<ShardDescriptor>,
+    loaded: BTreeMap<ShardId, LoadedShard>,
+    loaded_bytes: usize,
+}
+
+impl ShardedIndex {
+    /// Decodes a sharded root envelope without loading lexical artifacts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for unsupported versions, malformed post metadata,
+    /// invalid descriptor order, non-canonical filenames, or trailing bytes.
+    pub fn from_root_bytes(bytes: &[u8]) -> Result<Self, ShardError> {
+        let (posts, descriptors) = decode_root(bytes)?;
+        Ok(Self {
+            posts,
+            descriptors,
+            loaded: BTreeMap::new(),
+            loaded_bytes: 0,
+        })
+    }
+
+    /// Returns the root descriptors in numeric and lexical order.
+    #[must_use]
+    pub fn descriptors(&self) -> &[ShardDescriptor] {
+        &self.descriptors
+    }
+
+    /// Plans the deduplicated shards needed to evaluate `query` completely.
+    #[must_use]
+    pub fn required_shards(&self, query: &str) -> Vec<ShardId> {
+        let terms = tokenize(query);
+        self.required_shards_for_terms(&terms)
+    }
+
+    /// Validates and loads one content-addressed lexical shard.
+    ///
+    /// Loading the same bytes more than once is idempotent. Supplying different
+    /// bytes for an already loaded identifier returns a conflict.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the artifact is unknown, malformed, corrupt,
+    /// conflicts with a loaded artifact, or disagrees with its root descriptor.
+    pub fn load_shard(&mut self, bytes: &[u8]) -> Result<ShardId, ShardError> {
+        let digest = sha256(bytes);
+        let Some(descriptor) = self
+            .descriptors
+            .iter()
+            .find(|descriptor| descriptor.digest == digest)
+        else {
+            let id = decode_shard_id(bytes)?;
+            if self.loaded.contains_key(&id) {
+                return Err(ShardError::ConflictingShard(id));
+            }
+            if self
+                .descriptors
+                .iter()
+                .any(|descriptor| descriptor.id == id)
+            {
+                return Err(ShardError::DigestMismatch { id });
+            }
+            return Err(ShardError::UnknownShard(id));
+        };
+
+        if let Some(loaded) = self.loaded.get(&descriptor.id) {
+            if loaded.digest == digest {
+                return Ok(descriptor.id);
+            }
+            return Err(ShardError::ConflictingShard(descriptor.id));
+        }
+        if bytes.len() != descriptor.encoded_len {
+            return Err(ShardError::LengthMismatch {
+                id: descriptor.id,
+                expected: descriptor.encoded_len,
+                actual: bytes.len(),
+            });
+        }
+
+        let shard = decode_shard(bytes, descriptor, self.posts.len())?;
+        let id = descriptor.id;
+        self.loaded_bytes = self
+            .loaded_bytes
+            .checked_add(bytes.len())
+            .ok_or(ShardError::MalformedShard("loaded byte count overflowed"))?;
+        self.loaded.insert(id, shard);
+        Ok(id)
+    }
+
+    /// Searches loaded shards while preserving monolithic exact-index ranking.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ShardError::NeedsShards`] when any lexical shard needed by the
+    /// query has not been loaded.
+    pub fn search(&self, query: &str, limit: usize) -> Result<Vec<&PostId>, ShardError> {
+        let search_terms = tokenize(query);
+        let required = self.required_shards_for_terms(&search_terms);
+        let missing: Vec<ShardId> = required
+            .iter()
+            .copied()
+            .filter(|id| !self.loaded.contains_key(id))
+            .collect();
+        if !missing.is_empty() {
+            return Err(ShardError::NeedsShards(missing));
+        }
+
+        let mut scores = title_scores(&self.posts, &search_terms);
+        let mut content_matches = vec![false; self.posts.len()];
+
+        for search_term in &search_terms {
+            content_matches.fill(false);
+            for id in self.required_shards_for_term(search_term) {
+                let shard = self
+                    .loaded
+                    .get(&id)
+                    .ok_or_else(|| ShardError::NeedsShards(vec![id]))?;
+                mark_content_matches(shard, search_term, &mut content_matches);
+            }
+            for (score, &content_match) in scores.iter_mut().zip(&content_matches) {
+                *score = score.saturating_add(usize::from(content_match));
+            }
+        }
+
+        Ok(ranked_posts(&self.posts, scores, limit))
+    }
+
+    /// Returns the number of currently loaded lexical shards.
+    #[must_use]
+    pub fn loaded_shard_count(&self) -> usize {
+        self.loaded.len()
+    }
+
+    /// Returns the sum of the encoded artifact lengths of loaded lexical shards.
+    ///
+    /// This is an accounting metric for transferred shard data, not the retained
+    /// decoded heap size or the WebAssembly linear-memory allocation.
+    #[must_use]
+    pub const fn loaded_shard_bytes(&self) -> usize {
+        self.loaded_bytes
+    }
+
+    fn required_shards_for_terms(&self, terms: &[String]) -> Vec<ShardId> {
+        terms
+            .iter()
+            .flat_map(|term| self.required_shards_for_term(term))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    fn required_shards_for_term(&self, term: &str) -> Vec<ShardId> {
+        let prefix = term.chars().count() >= MIN_PREFIX_LEN;
+        self.descriptors
+            .iter()
+            .filter(|descriptor| {
+                if prefix {
+                    descriptor.last_term.as_str() >= term
+                        && (descriptor.first_term.as_str() <= term
+                            || descriptor.first_term.starts_with(term))
+                } else {
+                    descriptor.first_term.as_str() <= term && term <= descriptor.last_term.as_str()
+                }
+            })
+            .map(|descriptor| descriptor.id)
+            .collect()
+    }
+}
+
+pub(crate) fn build_bundle(
+    index: &SearchIndex,
+    config: ShardConfig,
+) -> Result<ShardedIndexBundle, ShardError> {
+    match &index.data {
+        SearchIndexData::Exact(exact) => build_exact_bundle(exact, config),
+        SearchIndexData::Xor8(_) => Err(ShardError::UnsupportedBackend),
+    }
+}
+
+fn build_exact_bundle(
+    index: &ExactIndex,
+    config: ShardConfig,
+) -> Result<ShardedIndexBundle, ShardError> {
+    validate_exact_index(index)?;
+    let ranges = partition_ranges(index, config)?;
+    let mut artifacts = Vec::with_capacity(ranges.len());
+
+    for (number, (start, end)) in ranges.into_iter().enumerate() {
+        let numeric_id = u32::try_from(number)
+            .map_err(|_error| ShardError::MalformedShard("too many lexical shards"))?;
+        let id = ShardId::new(numeric_id);
+        let bytes = encode_shard(
+            id,
+            index
+                .terms
+                .get(start..end)
+                .ok_or(ShardError::MalformedShard("shard term range is invalid"))?,
+            index
+                .postings
+                .get(start..end)
+                .ok_or(ShardError::MalformedShard("shard posting range is invalid"))?,
+            index.posts.len(),
+        )?;
+        let digest = sha256(&bytes);
+        let first_term = index
+            .terms
+            .get(start)
+            .cloned()
+            .ok_or(ShardError::MalformedShard("shard has no first term"))?;
+        let last_position = end
+            .checked_sub(1)
+            .ok_or(ShardError::MalformedShard("shard range is empty"))?;
+        let last_term = index
+            .terms
+            .get(last_position)
+            .cloned()
+            .ok_or(ShardError::MalformedShard("shard has no last term"))?;
+        let descriptor = ShardDescriptor {
+            id,
+            first_term,
+            last_term,
+            filename: shard_filename(&digest),
+            encoded_len: bytes.len(),
+            digest,
+        };
+        artifacts.push(ShardArtifact { descriptor, bytes });
+    }
+
+    let descriptors: Vec<ShardDescriptor> = artifacts
+        .iter()
+        .map(|artifact| artifact.descriptor.clone())
+        .collect();
+    let root_bytes = encode_root(&index.posts, &descriptors);
+    Ok(ShardedIndexBundle {
+        root_bytes,
+        shards: artifacts,
+    })
+}
+
+fn validate_exact_index(index: &ExactIndex) -> Result<(), ShardError> {
+    if index.terms.len() != index.postings.len() {
+        return Err(ShardError::MalformedShard(
+            "terms and postings must have equal lengths",
+        ));
+    }
+    if index.terms.iter().any(String::is_empty)
+        || !index.terms.windows(2).all(|pair| pair[0] < pair[1])
+    {
+        return Err(ShardError::MalformedShard(
+            "terms must be non-empty, sorted, and unique",
+        ));
+    }
+    for postings in &index.postings {
+        validate_postings(postings, index.posts.len())?;
+    }
+    Ok(())
+}
+
+fn partition_ranges(
+    index: &ExactIndex,
+    config: ShardConfig,
+) -> Result<Vec<(usize, usize)>, ShardError> {
+    let mut ranges = Vec::new();
+    let mut start = 0_usize;
+    while start < index.terms.len() {
+        let number = u32::try_from(ranges.len())
+            .map_err(|_error| ShardError::MalformedShard("too many lexical shards"))?;
+        let id = ShardId::new(number);
+        let mut end = start;
+        let mut payload_len = 0_usize;
+        while end < index.terms.len() {
+            let term = index
+                .terms
+                .get(end)
+                .ok_or(ShardError::MalformedShard("term range is invalid"))?;
+            let postings = index
+                .postings
+                .get(end)
+                .ok_or(ShardError::MalformedShard("posting range is invalid"))?;
+            let term_len = encoded_term_len(term, postings)?;
+            let candidate_payload = payload_len
+                .checked_add(term_len)
+                .ok_or(ShardError::MalformedShard("shard size overflowed"))?;
+            let candidate_count = end
+                .checked_sub(start)
+                .and_then(|count| count.checked_add(1))
+                .ok_or(ShardError::MalformedShard("shard term count overflowed"))?;
+            let candidate_len = shard_encoded_len(id, candidate_count, candidate_payload)?;
+            if end > start && candidate_len > config.target_bytes() {
+                break;
+            }
+            payload_len = candidate_payload;
+            end = end
+                .checked_add(1)
+                .ok_or(ShardError::MalformedShard("shard range overflowed"))?;
+            if candidate_len > config.target_bytes() {
+                break;
+            }
+        }
+        ranges.push((start, end));
+        start = end;
+    }
+    Ok(ranges)
+}
+
+fn encoded_term_len(term: &str, postings: &[usize]) -> Result<usize, ShardError> {
+    let mut length = varint_len(term.len())
+        .checked_add(term.len())
+        .and_then(|value| value.checked_add(varint_len(postings.len())))
+        .ok_or(ShardError::MalformedShard("encoded term size overflowed"))?;
+    let mut previous = 0_usize;
+    for (position, &document) in postings.iter().enumerate() {
+        let delta = posting_delta(position, document, previous)?;
+        length = length
+            .checked_add(varint_len(delta))
+            .ok_or(ShardError::MalformedShard(
+                "encoded posting size overflowed",
+            ))?;
+        previous = document;
+    }
+    Ok(length)
+}
+
+fn shard_encoded_len(
+    id: ShardId,
+    term_count: usize,
+    payload_len: usize,
+) -> Result<usize, ShardError> {
+    SHARD_MAGIC
+        .len()
+        .checked_add(1)
+        .and_then(|value| value.checked_add(varint_len(id_value(id))))
+        .and_then(|value| value.checked_add(varint_len(term_count)))
+        .and_then(|value| value.checked_add(payload_len))
+        .ok_or(ShardError::MalformedShard("encoded shard size overflowed"))
+}
+
+fn encode_root(posts: &[PostId], descriptors: &[ShardDescriptor]) -> Vec<u8> {
+    let mut encoded_posts = Vec::new();
+    write_varint(&mut encoded_posts, posts.len());
+    for post in posts {
+        write_string(&mut encoded_posts, &post.title);
+        write_string(&mut encoded_posts, &post.url);
+        write_string(&mut encoded_posts, &post.meta);
+    }
+
+    let mut output = Vec::new();
+    output.extend_from_slice(ROOT_MAGIC);
+    output.push(ROOT_VERSION);
+    write_varint(&mut output, encoded_posts.len());
+    output.extend_from_slice(&encoded_posts);
+    write_varint(&mut output, descriptors.len());
+    for descriptor in descriptors {
+        write_varint(&mut output, id_value(descriptor.id));
+        write_string(&mut output, &descriptor.first_term);
+        write_string(&mut output, &descriptor.last_term);
+        write_varint(&mut output, descriptor.encoded_len);
+        output.extend_from_slice(&descriptor.digest);
+        write_string(&mut output, &descriptor.filename);
+    }
+    output
+}
+
+fn decode_posts(input: &[u8]) -> Result<Vec<PostId>, &'static str> {
+    const MINIMUM_ENCODED_POST_BYTES: usize = 3;
+
+    let mut cursor = 0_usize;
+    let post_count = read_varint(input, &mut cursor)?;
+    let remaining = input.len().saturating_sub(cursor);
+    if post_count > remaining / MINIMUM_ENCODED_POST_BYTES {
+        return Err("post count exceeds the post payload bounds");
+    }
+
+    let mut posts = Vec::with_capacity(post_count);
+    for _position in 0..post_count {
+        let title = read_string(input, &mut cursor)?;
+        let url = read_string(input, &mut cursor)?;
+        let meta = read_string(input, &mut cursor)?;
+        posts.push(PostId { title, url, meta });
+    }
+    if cursor != input.len() {
+        return Err("post payload has trailing bytes");
+    }
+    Ok(posts)
+}
+
+fn decode_root(bytes: &[u8]) -> Result<(Vec<PostId>, Vec<ShardDescriptor>), ShardError> {
+    let mut cursor = envelope_cursor(bytes, ROOT_MAGIC, ROOT_VERSION, true)?;
+    let posts_len = read_varint(bytes, &mut cursor).map_err(ShardError::MalformedRoot)?;
+    let posts_section =
+        take_section(bytes, &mut cursor, posts_len).map_err(ShardError::MalformedRoot)?;
+    let posts = decode_posts(posts_section).map_err(ShardError::MalformedRoot)?;
+
+    let descriptor_count = read_varint(bytes, &mut cursor).map_err(ShardError::MalformedRoot)?;
+    if descriptor_count
+        > bytes
+            .len()
+            .saturating_sub(cursor)
+            .checked_div(MINIMUM_DESCRIPTOR_BYTES)
+            .unwrap_or(0)
+    {
+        return Err(ShardError::MalformedRoot(
+            "descriptor count exceeds the remaining root bytes",
+        ));
+    }
+    if posts.is_empty() && descriptor_count != 0 {
+        return Err(ShardError::MalformedRoot(
+            "an empty post table cannot have lexical shards",
+        ));
+    }
+
+    let mut descriptors = Vec::with_capacity(descriptor_count);
+    for position in 0..descriptor_count {
+        let encoded_id = read_varint(bytes, &mut cursor).map_err(ShardError::MalformedRoot)?;
+        let numeric_id = u32::try_from(encoded_id)
+            .map_err(|_error| ShardError::MalformedRoot("shard id exceeds u32"))?;
+        let id = ShardId::new(numeric_id);
+        let expected = u32::try_from(position)
+            .map_err(|_error| ShardError::MalformedRoot("too many descriptors"))?;
+        if numeric_id != expected {
+            return Err(ShardError::MalformedRoot(
+                "shard ids must be contiguous and ordered",
+            ));
+        }
+        let first_term = read_string(bytes, &mut cursor).map_err(ShardError::MalformedRoot)?;
+        let last_term = read_string(bytes, &mut cursor).map_err(ShardError::MalformedRoot)?;
+        if first_term.is_empty() || first_term > last_term {
+            return Err(ShardError::MalformedRoot(
+                "descriptor term range is empty or reversed",
+            ));
+        }
+        if descriptors
+            .last()
+            .is_some_and(|previous: &ShardDescriptor| previous.last_term >= first_term)
+        {
+            return Err(ShardError::MalformedRoot(
+                "descriptor term ranges must be strictly ordered",
+            ));
+        }
+        let encoded_len = read_varint(bytes, &mut cursor).map_err(ShardError::MalformedRoot)?;
+        if encoded_len == 0 {
+            return Err(ShardError::MalformedRoot(
+                "descriptor artifact length must be nonzero",
+            ));
+        }
+        let digest_section =
+            take_section(bytes, &mut cursor, DIGEST_LEN).map_err(ShardError::MalformedRoot)?;
+        let digest: [u8; DIGEST_LEN] = digest_section
+            .try_into()
+            .map_err(|_error| ShardError::MalformedRoot("digest length is invalid"))?;
+        if descriptors
+            .iter()
+            .any(|descriptor| descriptor.digest == digest)
+        {
+            return Err(ShardError::MalformedRoot(
+                "descriptor digests must be unique",
+            ));
+        }
+        let filename = read_string(bytes, &mut cursor).map_err(ShardError::MalformedRoot)?;
+        if filename != shard_filename(&digest) {
+            return Err(ShardError::MalformedRoot(
+                "descriptor filename is not content-addressed",
+            ));
+        }
+        descriptors.push(ShardDescriptor {
+            id,
+            first_term,
+            last_term,
+            filename,
+            encoded_len,
+            digest,
+        });
+    }
+    if cursor != bytes.len() {
+        return Err(ShardError::MalformedRoot("root has trailing bytes"));
+    }
+    Ok((posts, descriptors))
+}
+
+fn encode_shard(
+    id: ShardId,
+    terms: &[String],
+    postings: &[Vec<usize>],
+    document_count: usize,
+) -> Result<Vec<u8>, ShardError> {
+    if terms.is_empty() || terms.len() != postings.len() {
+        return Err(ShardError::MalformedShard(
+            "shard terms and postings must be non-empty and aligned",
+        ));
+    }
+    let mut output = Vec::new();
+    output.extend_from_slice(SHARD_MAGIC);
+    output.push(SHARD_VERSION);
+    write_varint(&mut output, id_value(id));
+    write_varint(&mut output, terms.len());
+    for (term, posting_list) in terms.iter().zip(postings) {
+        if term.is_empty() {
+            return Err(ShardError::MalformedShard("shard term is empty"));
+        }
+        validate_postings(posting_list, document_count)?;
+        write_string(&mut output, term);
+        write_varint(&mut output, posting_list.len());
+        let mut previous = 0_usize;
+        for (position, &document) in posting_list.iter().enumerate() {
+            let delta = posting_delta(position, document, previous)?;
+            write_varint(&mut output, delta);
+            previous = document;
+        }
+    }
+    Ok(output)
+}
+
+fn decode_shard(
+    bytes: &[u8],
+    descriptor: &ShardDescriptor,
+    document_count: usize,
+) -> Result<LoadedShard, ShardError> {
+    let mut cursor = envelope_cursor(bytes, SHARD_MAGIC, SHARD_VERSION, false)?;
+    let encoded_id = read_varint(bytes, &mut cursor).map_err(ShardError::MalformedShard)?;
+    let numeric_id = u32::try_from(encoded_id)
+        .map_err(|_error| ShardError::MalformedShard("shard id exceeds u32"))?;
+    let actual = ShardId::new(numeric_id);
+    if actual != descriptor.id {
+        return Err(ShardError::WrongShardId {
+            expected: descriptor.id,
+            actual,
+        });
+    }
+    let term_count = read_varint(bytes, &mut cursor).map_err(ShardError::MalformedShard)?;
+    if term_count == 0
+        || term_count
+            > bytes
+                .len()
+                .saturating_sub(cursor)
+                .checked_div(MINIMUM_TERM_BYTES)
+                .unwrap_or(0)
+    {
+        return Err(ShardError::MalformedShard("shard term count is invalid"));
+    }
+
+    let mut terms = Vec::with_capacity(term_count);
+    let mut postings = Vec::with_capacity(term_count);
+    for _position in 0..term_count {
+        let term = read_string(bytes, &mut cursor).map_err(ShardError::MalformedShard)?;
+        if term.is_empty()
+            || terms
+                .last()
+                .is_some_and(|previous: &String| previous >= &term)
+        {
+            return Err(ShardError::MalformedShard(
+                "shard terms must be non-empty, sorted, and unique",
+            ));
+        }
+        let posting_list = decode_posting_list(bytes, &mut cursor, document_count)?;
+        terms.push(term);
+        postings.push(posting_list);
+    }
+    if cursor != bytes.len() {
+        return Err(ShardError::MalformedShard("shard has trailing bytes"));
+    }
+    if terms.first() != Some(&descriptor.first_term) || terms.last() != Some(&descriptor.last_term)
+    {
+        return Err(ShardError::MalformedShard(
+            "shard terms disagree with the descriptor range",
+        ));
+    }
+    Ok(LoadedShard {
+        terms,
+        postings,
+        digest: descriptor.digest,
+    })
+}
+
+fn decode_shard_id(bytes: &[u8]) -> Result<ShardId, ShardError> {
+    let mut cursor = envelope_cursor(bytes, SHARD_MAGIC, SHARD_VERSION, false)?;
+    let encoded_id = read_varint(bytes, &mut cursor).map_err(ShardError::MalformedShard)?;
+    let numeric_id = u32::try_from(encoded_id)
+        .map_err(|_error| ShardError::MalformedShard("shard id exceeds u32"))?;
+    Ok(ShardId::new(numeric_id))
+}
+
+fn decode_posting_list(
+    bytes: &[u8],
+    cursor: &mut usize,
+    document_count: usize,
+) -> Result<Vec<usize>, ShardError> {
+    let posting_count = read_varint(bytes, cursor).map_err(ShardError::MalformedShard)?;
+    if posting_count == 0
+        || posting_count > document_count
+        || posting_count > bytes.len().saturating_sub(*cursor)
+    {
+        return Err(ShardError::MalformedShard(
+            "posting count is invalid for this root",
+        ));
+    }
+    let mut documents = Vec::with_capacity(posting_count);
+    let mut previous = 0_usize;
+    for position in 0..posting_count {
+        let delta = read_varint(bytes, cursor).map_err(ShardError::MalformedShard)?;
+        if position > 0 && delta == 0 {
+            return Err(ShardError::MalformedShard(
+                "posting documents must be strictly increasing",
+            ));
+        }
+        let document = previous
+            .checked_add(delta)
+            .ok_or(ShardError::MalformedShard("posting document overflowed"))?;
+        if document >= document_count {
+            return Err(ShardError::MalformedShard(
+                "posting document is out of range",
+            ));
+        }
+        documents.push(document);
+        previous = document;
+    }
+    Ok(documents)
+}
+
+fn validate_postings(postings: &[usize], document_count: usize) -> Result<(), ShardError> {
+    if postings.is_empty() {
+        return Err(ShardError::MalformedShard(
+            "posting lists must not be empty",
+        ));
+    }
+    let mut previous = None;
+    for &document in postings {
+        if document >= document_count || previous.is_some_and(|value| value >= document) {
+            return Err(ShardError::MalformedShard(
+                "posting documents must be in range and strictly increasing",
+            ));
+        }
+        previous = Some(document);
+    }
+    Ok(())
+}
+
+fn posting_delta(position: usize, document: usize, previous: usize) -> Result<usize, ShardError> {
+    if position == 0 {
+        Ok(document)
+    } else {
+        document
+            .checked_sub(previous)
+            .filter(|delta| *delta > 0)
+            .ok_or(ShardError::MalformedShard(
+                "posting documents must be strictly increasing",
+            ))
+    }
+}
+
+fn mark_content_matches(shard: &LoadedShard, search_term: &str, matches: &mut [bool]) {
+    let matching_terms = matching_term_range(&shard.terms, search_term);
+    for posting_list in shard
+        .postings
+        .iter()
+        .skip(matching_terms.start)
+        .take(matching_terms.len())
+    {
+        for &document in posting_list {
+            if let Some(content_match) = matches.get_mut(document) {
+                *content_match = true;
+            }
+        }
+    }
+}
+
+fn envelope_cursor(
+    bytes: &[u8],
+    magic: &[u8],
+    version: u8,
+    root: bool,
+) -> Result<usize, ShardError> {
+    let Some(after_magic) = bytes.strip_prefix(magic) else {
+        return if root {
+            Err(ShardError::MalformedRoot("magic is missing"))
+        } else {
+            Err(ShardError::MalformedShard("magic is missing"))
+        };
+    };
+    let Some((&actual_version, _payload)) = after_magic.split_first() else {
+        return if root {
+            Err(ShardError::MalformedRoot("version is missing"))
+        } else {
+            Err(ShardError::MalformedShard("version is missing"))
+        };
+    };
+    if actual_version != version {
+        return if root {
+            Err(ShardError::MalformedRoot("version is unsupported"))
+        } else {
+            Err(ShardError::MalformedShard("version is unsupported"))
+        };
+    }
+    magic.len().checked_add(1).ok_or(if root {
+        ShardError::MalformedRoot("envelope cursor overflowed")
+    } else {
+        ShardError::MalformedShard("envelope cursor overflowed")
+    })
+}
+
+fn write_string(output: &mut Vec<u8>, value: &str) {
+    write_varint(output, value.len());
+    output.extend_from_slice(value.as_bytes());
+}
+
+fn read_string(input: &[u8], cursor: &mut usize) -> Result<String, &'static str> {
+    let length = read_varint(input, cursor)?;
+    let section = take_section(input, cursor, length)?;
+    let value = std::str::from_utf8(section).map_err(|_error| "string is not valid UTF-8")?;
+    Ok(value.to_owned())
+}
+
+fn take_section<'input>(
+    input: &'input [u8],
+    cursor: &mut usize,
+    length: usize,
+) -> Result<&'input [u8], &'static str> {
+    let end = (*cursor)
+        .checked_add(length)
+        .ok_or("section length overflowed")?;
+    let section = input
+        .get(*cursor..end)
+        .ok_or("section extends beyond the envelope")?;
+    *cursor = end;
+    Ok(section)
+}
+
+fn write_varint(output: &mut Vec<u8>, mut value: usize) {
+    while value >= 0x80 {
+        output.push((value.to_le_bytes()[0] & 0x7f) | 0x80);
+        value >>= 7;
+    }
+    output.push(value.to_le_bytes()[0]);
+}
+
+fn read_varint(input: &[u8], cursor: &mut usize) -> Result<usize, &'static str> {
+    let start = *cursor;
+    let mut value = 0_usize;
+    for shift in (0..usize::BITS).step_by(7) {
+        let byte = input.get(*cursor).copied().ok_or("varint is truncated")?;
+        *cursor = (*cursor).checked_add(1).ok_or("varint cursor overflowed")?;
+        let payload = usize::from(byte & 0x7f);
+        if payload > (usize::MAX >> shift) {
+            return Err("varint exceeds the platform range");
+        }
+        value |= payload << shift;
+        if byte & 0x80 == 0 {
+            let consumed = (*cursor)
+                .checked_sub(start)
+                .ok_or("varint cursor moved backwards")?;
+            if consumed != varint_len(value) {
+                return Err("varint is not canonically encoded");
+            }
+            return Ok(value);
+        }
+    }
+    Err("varint is unterminated")
+}
+
+const fn varint_len(mut value: usize) -> usize {
+    let mut length = 1_usize;
+    while value >= 0x80 {
+        length = length.saturating_add(1);
+        value >>= 7;
+    }
+    length
+}
+
+fn id_value(id: ShardId) -> usize {
+    match usize::try_from(id.get()) {
+        Ok(value) => value,
+        Err(_error) => usize::MAX,
+    }
+}
+
+fn sha256(bytes: &[u8]) -> [u8; DIGEST_LEN] {
+    Sha256::digest(bytes).into()
+}
+
+fn shard_filename(digest: &[u8; DIGEST_LEN]) -> String {
+    format!("{}{SHARD_FILE_SUFFIX}", digest_hex(digest))
+}
+
+fn digest_hex(digest: &[u8; DIGEST_LEN]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(DIGEST_LEN.saturating_mul(2));
+    for &byte in digest {
+        output.push(char::from(HEX[usize::from(byte >> 4)]));
+        output.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    output
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -38,6 +38,8 @@ fn test_cli_wasm_mode() {
     );
 
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let crate_temp_dir = TempDir::new().expect("Failed to create generated crate directory");
+    let generated_crate = crate_temp_dir.path().join("generated-crate");
 
     let current_dir = std::env::current_dir().unwrap();
     let output = Command::new("cargo")
@@ -45,8 +47,12 @@ fn test_cli_wasm_mode() {
             "run",
             "--features=bin",
             "--",
+            "--shard-size",
+            "4096",
             "-m",
             "wasm",
+            "--crate-path",
+            generated_crate.to_str().unwrap(),
             "-p",
             temp_dir.path().to_str().unwrap(),
             "--engine-version",
@@ -67,36 +73,246 @@ fn test_cli_wasm_mode() {
         panic!("WASM build failed unexpectedly");
     }
 
-    // Verify that WASM and JS files were created
-    let wasm_files: Vec<_> = std::fs::read_dir(&temp_dir)
-        .expect("Failed to read output directory")
-        .filter_map(std::result::Result::ok)
-        .filter(|entry| {
-            entry
-                .path()
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .is_some_and(|ext| ext == "wasm" || ext == "js")
-        })
-        .collect();
+    assert_sharded_wasm_artifacts(&temp_dir);
+    assert_sharded_loader(&temp_dir);
 
-    assert!(!wasm_files.is_empty(), "No WASM/JS files were generated");
+    assert_release_wasm_output(&temp_dir, &generated_crate, &current_dir);
+    assert_xor8_wasm_output(&generated_crate, &current_dir);
+}
 
-    // Specifically check for both .wasm and .js files
-    let has_wasm = wasm_files
-        .iter()
-        .any(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("wasm"));
-    let has_js = wasm_files
-        .iter()
-        .any(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("js"));
-
-    assert!(has_wasm, "No .wasm file was generated");
-    assert!(has_js, "No .js file was generated");
+fn assert_sharded_wasm_artifacts(temp_dir: &TempDir) {
+    assert!(temp_dir.path().join("tinysearch_engine.wasm").exists());
+    assert!(temp_dir.path().join("tinysearch_engine.js").exists());
+    assert!(temp_dir.path().join("tinysearch.root").exists());
 
     let demo = std::fs::read_to_string(temp_dir.path().join("demo.html"))
         .expect("Failed to read generated demo");
     assert!(demo.contains("addEventListener('input', performSearch)"));
     assert!(demo.contains("Results update as you type"));
+
+    let shard_count = std::fs::read_dir(temp_dir)
+        .expect("Failed to inspect generated shards")
+        .filter_map(std::result::Result::ok)
+        .filter(|entry| {
+            entry
+                .path()
+                .extension()
+                .and_then(|extension| extension.to_str())
+                == Some("tinysearch-shard")
+        })
+        .count();
+    assert!(shard_count > 1, "Expected multiple lazy-loadable shards");
+}
+
+fn assert_sharded_loader(temp_dir: &TempDir) {
+    let output = Command::new("node")
+        .args([
+            "tests/wasm_loader_test.mjs",
+            temp_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute Node.js loader integration test");
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        eprintln!("Loader test failed. Stdout: {stdout}");
+        eprintln!("Loader test failed. Stderr: {stderr}");
+    }
+    assert!(
+        output.status.success(),
+        "Generated JS/WASM loader integration test failed"
+    );
+}
+
+fn assert_release_wasm_output(
+    temp_dir: &TempDir,
+    generated_crate: &std::path::Path,
+    current_dir: &std::path::Path,
+) {
+    let retained_shard = temp_dir
+        .path()
+        .join("0000000000000000000000000000000000000000000000000000000000000000.tinysearch-shard");
+    std::fs::write(&retained_shard, b"previous immutable shard")
+        .expect("Failed to write retained shard fixture");
+
+    let release_output = Command::new("cargo")
+        .args([
+            "run",
+            "--features=bin",
+            "--",
+            "--release",
+            "--shard-size",
+            "4096",
+            "-m",
+            "wasm",
+            "--crate-path",
+            generated_crate.to_str().unwrap(),
+            "-p",
+            temp_dir.path().to_str().unwrap(),
+            "--engine-version",
+            &format!("path=\"{}\"", current_dir.display()),
+            "fixtures/index.json",
+        ])
+        .output()
+        .expect("Failed to execute release WASM command");
+    if !release_output.status.success() {
+        let stderr = String::from_utf8_lossy(&release_output.stderr);
+        let stdout = String::from_utf8_lossy(&release_output.stdout);
+        eprintln!("Release WASM build failed. Stdout: {stdout}");
+        eprintln!("Release WASM build failed. Stderr: {stderr}");
+    }
+    assert!(release_output.status.success());
+    assert!(temp_dir.path().join("tinysearch_engine.wasm").exists());
+    assert!(temp_dir.path().join("tinysearch_engine.js").exists());
+    assert!(temp_dir.path().join("tinysearch.root").exists());
+    assert_eq!(
+        std::fs::read(&retained_shard).expect("Release removed the retained shard"),
+        b"previous immutable shard"
+    );
+    assert!(
+        !temp_dir.path().join("demo.html").exists(),
+        "Release output must omit the demo"
+    );
+    assert!(
+        std::fs::read_dir(temp_dir)
+            .expect("Failed to inspect release shards")
+            .filter_map(std::result::Result::ok)
+            .any(|entry| {
+                entry
+                    .path()
+                    .extension()
+                    .and_then(|extension| extension.to_str())
+                    == Some("tinysearch-shard")
+            }),
+        "Release output must retain sharded artifacts"
+    );
+}
+
+fn assert_xor8_wasm_output(generated_crate: &std::path::Path, current_dir: &std::path::Path) {
+    let output_dir = TempDir::new().expect("Failed to create Xor8 output directory");
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--features=bin",
+            "--",
+            "--release",
+            "--indexer",
+            "xor8",
+            "-m",
+            "wasm",
+            "--crate-path",
+            generated_crate.to_str().unwrap(),
+            "-p",
+            output_dir.path().to_str().unwrap(),
+            "--engine-version",
+            &format!("path=\"{}\"", current_dir.display()),
+            "fixtures/index.json",
+        ])
+        .output()
+        .expect("Failed to generate Xor8 WASM output");
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        eprintln!("Xor8 WASM build failed. Stdout: {stdout}");
+        eprintln!("Xor8 WASM build failed. Stderr: {stderr}");
+    }
+    assert!(output.status.success());
+
+    let loader_test = Command::new("node")
+        .args([
+            "tests/legacy_wasm_loader_test.mjs",
+            output_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute Xor8 loader integration test");
+    if !loader_test.status.success() {
+        let stderr = String::from_utf8_lossy(&loader_test.stderr);
+        let stdout = String::from_utf8_lossy(&loader_test.stdout);
+        eprintln!("Xor8 loader test failed. Stdout: {stdout}");
+        eprintln!("Xor8 loader test failed. Stderr: {stderr}");
+    }
+    assert!(loader_test.status.success());
+}
+
+#[test]
+fn test_cli_exact_crate_non_top_level_keeps_embedded_search_api() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let current_dir = std::env::current_dir().expect("Failed to resolve repository directory");
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--features=bin",
+            "--",
+            "-m",
+            "crate",
+            "--indexer",
+            "exact",
+            "--non-top-level-crate",
+            "-p",
+            temp_dir.path().to_str().unwrap(),
+            "--engine-version",
+            &format!(
+                "path=\"{current_dir}\"",
+                current_dir = current_dir.display()
+            ),
+            "fixtures/index.json",
+        ])
+        .output()
+        .expect("Failed to generate exact embedded crate");
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        eprintln!("Exact crate generation failed. Stdout: {stdout}");
+        eprintln!("Exact crate generation failed. Stderr: {stderr}");
+    }
+    assert!(output.status.success());
+
+    let storage_path = temp_dir.path().join("src/storage");
+    assert!(storage_path.exists(), "Exact crate must embed src/storage");
+    assert!(
+        !temp_dir.path().join("index").exists(),
+        "Crate mode must not emit external sharded artifacts"
+    );
+    let library = std::fs::read_to_string(temp_dir.path().join("src/lib.rs"))
+        .expect("Failed to read generated exact crate library");
+    assert!(library.contains("pub fn search_local"));
+    assert!(library.contains("include_bytes!(\"storage\")"));
+    assert!(!library.contains("ShardedIndex"));
+
+    let cargo_toml = std::fs::read_to_string(temp_dir.path().join("Cargo.toml"))
+        .expect("Failed to read generated Cargo.toml");
+    assert!(!cargo_toml.contains("[workspace]"));
+    assert!(cargo_toml.contains("[lib]"));
+
+    let smoke_bin_dir = temp_dir.path().join("src/bin");
+    std::fs::create_dir_all(&smoke_bin_dir).expect("Failed to create smoke binary directory");
+    std::fs::write(
+        smoke_bin_dir.join("search_smoke.rs"),
+        r#"fn main() {
+    let results = tinysearch_engine::search_local("decades".to_owned(), 5);
+    assert!(!results.is_empty());
+}
+"#,
+    )
+    .expect("Failed to write search_local smoke binary");
+
+    let smoke_output = Command::new("cargo")
+        .args([
+            "run",
+            "--manifest-path",
+            temp_dir.path().join("Cargo.toml").to_str().unwrap(),
+            "--bin",
+            "search_smoke",
+        ])
+        .output()
+        .expect("Failed to compile and run generated exact crate");
+    if !smoke_output.status.success() {
+        let stderr = String::from_utf8_lossy(&smoke_output.stderr);
+        let stdout = String::from_utf8_lossy(&smoke_output.stdout);
+        eprintln!("Generated exact crate smoke test failed. Stdout: {stdout}");
+        eprintln!("Generated exact crate smoke test failed. Stderr: {stderr}");
+    }
+    assert!(smoke_output.status.success());
 }
 
 #[test]

--- a/tests/legacy_wasm_loader_test.mjs
+++ b/tests/legacy_wasm_loader_test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const outputArgument = process.argv[2];
+if (!outputArgument) {
+    throw new Error('Usage: node tests/legacy_wasm_loader_test.mjs <generated-output-directory>');
+}
+
+const outputDirectory = path.resolve(outputArgument);
+
+async function findArtifact(extension) {
+    const entries = await readdir(outputDirectory, { withFileTypes: true });
+    const matches = entries
+        .filter((entry) => entry.isFile() && entry.name.endsWith(extension))
+        .map((entry) => path.join(outputDirectory, entry.name));
+    assert.equal(matches.length, 1, `expected one ${extension} artifact, found ${matches.join(', ')}`);
+    return matches[0];
+}
+
+function createFileFetch() {
+    const counts = new Map();
+    return {
+        counts,
+        async fetch(input) {
+            const url = input instanceof URL ? input : new URL(String(input));
+            counts.set(url.href, (counts.get(url.href) ?? 0) + 1);
+            assert.equal(url.protocol, 'file:');
+            const bytes = await readFile(fileURLToPath(url));
+            return new Response(bytes, {
+                status: 200,
+                headers: { 'content-type': 'application/octet-stream' },
+            });
+        },
+    };
+}
+
+let loaderModulePromise;
+function loadGeneratedLoader() {
+    loaderModulePromise ??= (async () => {
+        const loader = await findArtifact('.js');
+        const loaderUrl = pathToFileURL(loader);
+        loaderUrl.searchParams.set('legacy-loader-test', String(Date.now()));
+        return import(loaderUrl.href);
+    })();
+    return loaderModulePromise;
+}
+
+function createStubEngine(TinySearch, searchFn) {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const engine = new TinySearch({
+        exports: {
+            memory,
+            search: searchFn,
+            free_search_result() {},
+            alloc_query() {
+                return 1024;
+            },
+            free_query() {},
+        },
+    });
+    return { engine, memory };
+}
+
+test('generated legacy WASM loader owns query memory and keeps an async API', async () => {
+    const wasm = await findArtifact('.wasm');
+    const { initTinysearch, init_tinysearch } = await loadGeneratedLoader();
+    assert.equal(init_tinysearch, initTinysearch);
+
+    const controller = createFileFetch();
+    const wasmUrl = pathToFileURL(wasm);
+    const engine = await initTinysearch({ wasmUrl, fetch: controller.fetch });
+    assert.equal(controller.counts.get(wasmUrl.href), 1, 'streaming fallback must reuse the response');
+
+    const results = await engine.search('decades', 5);
+    assert.ok(results.length > 0, 'known fixture query returned no Xor8 results');
+    assert.deepEqual(Object.keys(results[0]).sort(), ['meta', 'title', 'url']);
+
+    for (let iteration = 0; iteration < 20; iteration += 1) {
+        await engine.search('decades', 5);
+    }
+    const memoryBefore = engine.memory.buffer.byteLength;
+    for (let iteration = 0; iteration < 250; iteration += 1) {
+        await engine.search('decades', 5);
+    }
+    const memoryGrowth = engine.memory.buffer.byteLength - memoryBefore;
+    assert.ok(memoryGrowth <= 64 * 1024, `legacy WASM memory grew by ${memoryGrowth} bytes`);
+});
+
+test('legacy loader rejects corrupt ABI results', async () => {
+    const { TinySearch } = await loadGeneratedLoader();
+    const { engine: nullResultEngine } = createStubEngine(TinySearch, () => 0);
+    await assert.rejects(
+        nullResultEngine.search('query'),
+        /WASM search returned a null result pointer/,
+    );
+
+    const { engine: invalidJsonEngine, memory } = createStubEngine(TinySearch, () => 16);
+    new Uint8Array(memory.buffer).set(new TextEncoder().encode('not JSON\0'), 16);
+    await assert.rejects(invalidJsonEngine.search('query'), /WASM search returned invalid JSON/);
+});

--- a/tests/sharded_index.rs
+++ b/tests/sharded_index.rs
@@ -1,0 +1,646 @@
+//! Differential and wire-validation tests for the sharded exact index.
+
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::missing_docs_in_private_items,
+    clippy::panic,
+    clippy::unwrap_used
+)]
+
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeSet, HashMap};
+use tinysearch::{
+    BasicPost, ExactIndexBackend, IndexBackend, IndexedDocument, PostId, ShardConfig, ShardError,
+    ShardId, ShardedIndex, TinySearch, Xor8IndexBackend, search,
+};
+
+const TARGET_BYTES: usize = 48;
+const ROOT_MAGIC: &[u8] = b"tinysearch-sharded-root";
+const SHARD_MAGIC: &[u8] = b"tinysearch-shard";
+const ROOT_VERSION: u8 = 1;
+const SHARD_VERSION: u8 = 1;
+const SHARD_SUFFIX: &str = ".tinysearch-shard";
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn tokenize(text: &str) -> Vec<String> {
+    text.replace(
+        |character: char| !(character.is_alphabetic() || character == '\''),
+        " ",
+    )
+    .split_whitespace()
+    .map(str::to_lowercase)
+    .collect()
+}
+
+fn skewed_corpus() -> (tinysearch::SearchIndex, Vec<String>) {
+    let titles = [
+        "Rust Résumé",
+        "Rustacean Notes",
+        "Go Handbook",
+        "Café Culture",
+        "Über Guide",
+        "Tokyo 東京",
+        "A Small Post",
+        "Éclair Notes",
+        "Ångström Scale",
+        "Don't Panic",
+        "Punctuation & Unicode",
+        "Oversized Entry",
+    ];
+    let special_terms: [&[&str]; 12] = [
+        &["program", "programmer", "programming", "a"],
+        &["programming", "an"],
+        &["go", "rust"],
+        &["café", "co", "don't"],
+        &["über", "éclair"],
+        &["東京", "ångström"],
+        &["café", "résumé"],
+        &["über", "東京"],
+        &["don't", "go"],
+        &["a", "an", "co"],
+        &["punctuation", "unicode"],
+        &[],
+    ];
+
+    let mut all_terms = BTreeSet::new();
+    let mut documents = Vec::new();
+    for (number, (title, extras)) in titles.iter().zip(special_terms).enumerate() {
+        let mut terms = vec!["common".to_string(), format!("prefix{number:02}")];
+        terms.extend(extras.iter().map(ToString::to_string));
+        if number == titles.len() - 1 {
+            terms.push("z".repeat(180));
+        }
+        all_terms.extend(terms.iter().cloned());
+        all_terms.extend(tokenize(title));
+        documents.push(IndexedDocument::new(
+            PostId {
+                title: (*title).to_string(),
+                url: format!("/doc-{number:02}"),
+                meta: format!("{{\"ordinal\":{number}}}"),
+            },
+            terms,
+        ));
+    }
+    (
+        ExactIndexBackend.build(documents),
+        all_terms.into_iter().collect(),
+    )
+}
+
+fn config() -> ShardConfig {
+    ShardConfig::new(TARGET_BYTES).expect("nonzero target")
+}
+
+fn urls<'post>(posts: &[&'post PostId]) -> Vec<&'post str> {
+    posts.iter().map(|post| post.url.as_str()).collect()
+}
+
+fn fully_loaded(index: &tinysearch::SearchIndex) -> ShardedIndex {
+    let bundle = index
+        .to_sharded_bundle(config())
+        .expect("exact index should shard");
+    let mut sharded =
+        ShardedIndex::from_root_bytes(bundle.root_bytes()).expect("root should decode");
+    for artifact in bundle.shards() {
+        sharded
+            .load_shard(artifact.bytes())
+            .expect("generated shard should load");
+    }
+    sharded
+}
+
+fn unicode_prefixes(term: &str) -> Vec<&str> {
+    term.char_indices()
+        .map(|(position, _character)| position)
+        .skip(1)
+        .chain(std::iter::once(term.len()))
+        .map(|end| &term[..end])
+        .collect()
+}
+
+fn assert_same_results(
+    monolithic: &tinysearch::SearchIndex,
+    sharded: &ShardedIndex,
+    query: &str,
+    limit: usize,
+) {
+    let expected = search(monolithic, query, limit);
+    let actual = sharded
+        .search(query, limit)
+        .unwrap_or_else(|error| panic!("sharded search failed for {query:?}: {error}"));
+    assert_eq!(
+        urls(&actual),
+        urls(&expected),
+        "ordered URL mismatch for query {query:?}, limit {limit}"
+    );
+}
+
+#[test]
+fn defaults_validation_and_backend_support_are_explicit() {
+    assert_eq!(ShardConfig::default().target_bytes(), 64 * 1024);
+    assert!(matches!(
+        ShardConfig::new(0),
+        Err(ShardError::InvalidTargetBytes)
+    ));
+
+    let xor = Xor8IndexBackend.build(vec![IndexedDocument::new(
+        PostId {
+            title: "Xor".to_string(),
+            url: "/xor".to_string(),
+            meta: String::new(),
+        },
+        ["term".to_string()],
+    )]);
+    assert!(matches!(
+        xor.to_sharded_bundle(ShardConfig::default()),
+        Err(ShardError::UnsupportedBackend)
+    ));
+
+    let title_only = ExactIndexBackend.build(vec![IndexedDocument::new(
+        PostId {
+            title: "Headline Only".to_string(),
+            url: "/headline".to_string(),
+            meta: String::new(),
+        },
+        ["headline".to_string(), "only".to_string()],
+    )]);
+    let title_bundle = title_only
+        .to_sharded_bundle(config())
+        .expect("title-only index should shard");
+    assert!(title_bundle.shards().is_empty());
+    let title_index =
+        ShardedIndex::from_root_bytes(title_bundle.root_bytes()).expect("title root should decode");
+    assert!(title_index.required_shards("headline").is_empty());
+    assert_eq!(
+        urls(&title_index.search("headline", 5).expect("root-only search")),
+        ["/headline"]
+    );
+
+    let empty = ExactIndexBackend.build(Vec::new());
+    let empty_bundle = empty
+        .to_sharded_bundle(config())
+        .expect("empty exact index should shard");
+    assert!(empty_bundle.shards().is_empty());
+    let empty_index =
+        ShardedIndex::from_root_bytes(empty_bundle.root_bytes()).expect("empty root should decode");
+    assert!(
+        empty_index
+            .search("anything", 5)
+            .expect("empty search")
+            .is_empty()
+    );
+}
+
+#[test]
+fn sharded_search_matches_monolithic_for_terms_prefixes_and_limits() {
+    let (monolithic, terms) = skewed_corpus();
+    let sharded = fully_loaded(&monolithic);
+    let limits = [0, 1, 2, 5, 50];
+    let mut queries = BTreeSet::new();
+
+    for term in &terms {
+        queries.insert(term.clone());
+        for prefix in unicode_prefixes(term) {
+            queries.insert(prefix.to_string());
+        }
+    }
+    queries.extend([
+        "café!!!".to_string(),
+        "RUST, programming".to_string(),
+        "don't?".to_string(),
+        "東京。".to_string(),
+        "go".to_string(),
+        "a".to_string(),
+        "an".to_string(),
+        "pro pro".to_string(),
+        "program café 東京".to_string(),
+        "prefix00 prefix11 prefix00".to_string(),
+        "!!!".to_string(),
+    ]);
+
+    for query in queries {
+        for limit in limits {
+            assert_same_results(&monolithic, &sharded, &query, limit);
+        }
+    }
+}
+
+#[test]
+fn plans_fanout_and_supports_incremental_loading() -> TestResult {
+    let (monolithic, _terms) = skewed_corpus();
+    let bundle = monolithic.to_sharded_bundle(config())?;
+    let mut sharded = ShardedIndex::from_root_bytes(bundle.root_bytes())?;
+    let required = sharded.required_shards("pre prefix00 pre");
+    assert!(
+        required.len() > 2,
+        "expected prefix fanout, got {required:?}"
+    );
+    assert!(required.windows(2).all(|pair| pair[0] < pair[1]));
+
+    let error = sharded.search("pre prefix00 pre", 10).unwrap_err();
+    let ShardError::NeedsShards(initial_missing) = error else {
+        panic!("expected NeedsShards, got {error}");
+    };
+    assert_eq!(initial_missing, required);
+
+    let first = required[0];
+    let first_artifact = bundle
+        .shards()
+        .iter()
+        .find(|artifact| artifact.descriptor().id == first)
+        .expect("required artifact");
+    sharded.load_shard(first_artifact.bytes())?;
+    let ShardError::NeedsShards(after_one) = sharded.search("pre prefix00 pre", 10).unwrap_err()
+    else {
+        panic!("query unexpectedly succeeded with incomplete fanout");
+    };
+    assert_eq!(after_one, required[1..]);
+
+    for id in &required[1..] {
+        let artifact = bundle
+            .shards()
+            .iter()
+            .find(|artifact| artifact.descriptor().id == *id)
+            .expect("required artifact");
+        sharded.load_shard(artifact.bytes())?;
+    }
+    assert_same_results(&monolithic, &sharded, "pre prefix00 pre", 10);
+    assert_eq!(sharded.loaded_shard_count(), required.len());
+    let expected_bytes: usize = bundle
+        .shards()
+        .iter()
+        .filter(|artifact| required.contains(&artifact.descriptor().id))
+        .map(|artifact| artifact.bytes().len())
+        .sum();
+    assert_eq!(sharded.loaded_shard_bytes(), expected_bytes);
+    Ok(())
+}
+
+#[test]
+fn prefix_crosses_boundaries_and_content_scores_once_per_query_token() -> TestResult {
+    let (monolithic, _terms) = skewed_corpus();
+    let bundle = monolithic.to_sharded_bundle(config())?;
+    let required = ShardedIndex::from_root_bytes(bundle.root_bytes())?.required_shards("pro");
+    assert!(
+        required.len() >= 2,
+        "program terms should cross shard boundaries: {required:?}"
+    );
+
+    let sharded = fully_loaded(&monolithic);
+    assert_same_results(&monolithic, &sharded, "pro", 50);
+    let results = sharded.search("pro", 50)?;
+    assert_eq!(urls(&results), ["/doc-00", "/doc-01"]);
+
+    let repeated = sharded.search("pro pro", 50)?;
+    assert_eq!(urls(&repeated), ["/doc-00", "/doc-01"]);
+    Ok(())
+}
+
+#[test]
+fn public_build_order_does_not_change_content_addressed_artifacts() -> TestResult {
+    let posts = vec![
+        BasicPost {
+            title: "Second".to_string(),
+            url: "/second".to_string(),
+            body: Some("beta shared".to_string()),
+            meta: HashMap::new(),
+        },
+        BasicPost {
+            title: "First".to_string(),
+            url: "/first".to_string(),
+            body: Some("alpha shared".to_string()),
+            meta: HashMap::new(),
+        },
+    ];
+    let search = TinySearch::new();
+    let forward = search.build_index(&posts)?.to_sharded_bundle(config())?;
+    let reverse_posts: Vec<BasicPost> = posts.into_iter().rev().collect();
+    let reverse = search
+        .build_index(&reverse_posts)?
+        .to_sharded_bundle(config())?;
+
+    assert_eq!(forward, reverse);
+    Ok(())
+}
+
+#[test]
+fn direct_exact_backend_preserves_caller_order_for_equal_score_ties() -> TestResult {
+    let documents = vec![
+        IndexedDocument::new(
+            PostId {
+                title: "Second".to_string(),
+                url: "/second".to_string(),
+                meta: String::new(),
+            },
+            ["shared".to_string()],
+        ),
+        IndexedDocument::new(
+            PostId {
+                title: "First".to_string(),
+                url: "/first".to_string(),
+                meta: String::new(),
+            },
+            ["shared".to_string()],
+        ),
+    ];
+    let index = ExactIndexBackend.build(documents);
+    assert_eq!(urls(&search(&index, "shared", 10)), ["/second", "/first"]);
+
+    let sharded = fully_loaded(&index);
+    assert_eq!(urls(&sharded.search("shared", 10)?), ["/second", "/first"]);
+    Ok(())
+}
+
+#[test]
+fn bundles_are_deterministic_content_addressed_and_targeted() -> TestResult {
+    let (monolithic, _terms) = skewed_corpus();
+    let first = monolithic.to_sharded_bundle(config())?;
+    let second = monolithic.to_sharded_bundle(config())?;
+    assert_eq!(first, second);
+
+    let root_size = first.root_bytes().len();
+    let total_size: usize = first.shards().iter().map(|shard| shard.bytes().len()).sum();
+    let max_size = first
+        .shards()
+        .iter()
+        .map(|shard| shard.bytes().len())
+        .max()
+        .unwrap_or(0);
+    let context = format!(
+        "root={root_size} total_shards={total_size} max_shard={max_size} target={TARGET_BYTES}"
+    );
+    assert!(!first.shards().is_empty(), "{context}");
+    assert!(
+        max_size > TARGET_BYTES,
+        "oversized fixture missing; {context}"
+    );
+
+    for artifact in first.shards() {
+        let descriptor = artifact.descriptor();
+        let digest: [u8; 32] = Sha256::digest(artifact.bytes()).into();
+        assert_eq!(descriptor.digest, digest, "{context}");
+        assert_eq!(descriptor.encoded_len, artifact.bytes().len(), "{context}");
+        assert!(descriptor.filename.ends_with(SHARD_SUFFIX), "{context}");
+        assert!(
+            descriptor.filename.starts_with(&descriptor.digest_hex()),
+            "{context}"
+        );
+        assert!(
+            artifact.bytes().len() <= TARGET_BYTES || descriptor.first_term == descriptor.last_term,
+            "non-singleton shard exceeded target; {context}; descriptor={descriptor:?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn generated_root_and_shards_reject_corruption_and_duplicates() -> TestResult {
+    let (monolithic, _terms) = skewed_corpus();
+    let bundle = monolithic.to_sharded_bundle(config())?;
+
+    let mut bad_root = bundle.root_bytes().to_vec();
+    bad_root.push(0);
+    assert!(matches!(
+        ShardedIndex::from_root_bytes(&bad_root),
+        Err(ShardError::MalformedRoot(_))
+    ));
+    let mut bad_magic = bundle.root_bytes().to_vec();
+    bad_magic[0] ^= 1;
+    assert!(matches!(
+        ShardedIndex::from_root_bytes(&bad_magic),
+        Err(ShardError::MalformedRoot(_))
+    ));
+    assert!(matches!(
+        ShardedIndex::from_root_bytes(&bundle.root_bytes()[..ROOT_MAGIC.len()]),
+        Err(ShardError::MalformedRoot(_))
+    ));
+
+    let artifact = &bundle.shards()[0];
+    let mut corrupt = artifact.bytes().to_vec();
+    let last = corrupt.len() - 1;
+    corrupt[last] ^= 1;
+    let mut sharded = ShardedIndex::from_root_bytes(bundle.root_bytes())?;
+    assert!(matches!(
+        sharded.load_shard(&corrupt),
+        Err(ShardError::DigestMismatch { id }) if id == artifact.descriptor().id
+    ));
+
+    assert_eq!(
+        sharded.load_shard(artifact.bytes())?,
+        artifact.descriptor().id
+    );
+    let count = sharded.loaded_shard_count();
+    let bytes = sharded.loaded_shard_bytes();
+    assert_eq!(
+        sharded.load_shard(artifact.bytes())?,
+        artifact.descriptor().id
+    );
+    assert_eq!(sharded.loaded_shard_count(), count);
+    assert_eq!(sharded.loaded_shard_bytes(), bytes);
+    assert!(matches!(
+        sharded.load_shard(&corrupt),
+        Err(ShardError::ConflictingShard(id)) if id == artifact.descriptor().id
+    ));
+
+    let unknown = encode_test_shard(ShardId::new(999), "unknown", &[0], false);
+    assert!(matches!(
+        sharded.load_shard(&unknown),
+        Err(ShardError::UnknownShard(id)) if id == ShardId::new(999)
+    ));
+    Ok(())
+}
+
+#[test]
+fn handcrafted_envelopes_validate_length_digest_id_counts_and_trailing_bytes() -> TestResult {
+    let posts = [PostId {
+        title: "Root Post".to_string(),
+        url: "/root".to_string(),
+        meta: String::new(),
+    }];
+
+    let wrong_id_shard = encode_test_shard(ShardId::new(1), "alpha", &[0], false);
+    let wrong_id_root = encode_test_root(&posts, ShardId::new(0), "alpha", &wrong_id_shard, None);
+    let mut wrong_id_index = ShardedIndex::from_root_bytes(&wrong_id_root)?;
+    assert!(matches!(
+        wrong_id_index.load_shard(&wrong_id_shard),
+        Err(ShardError::WrongShardId { expected, actual })
+            if expected == ShardId::new(0) && actual == ShardId::new(1)
+    ));
+
+    let trailing_shard = encode_test_shard(ShardId::new(0), "alpha", &[0], true);
+    let trailing_root = encode_test_root(&posts, ShardId::new(0), "alpha", &trailing_shard, None);
+    let mut trailing_index = ShardedIndex::from_root_bytes(&trailing_root)?;
+    assert!(matches!(
+        trailing_index.load_shard(&trailing_shard),
+        Err(ShardError::MalformedShard(_))
+    ));
+
+    let empty_postings = encode_test_shard(ShardId::new(0), "alpha", &[], false);
+    let empty_root = encode_test_root(&posts, ShardId::new(0), "alpha", &empty_postings, None);
+    let mut empty_index = ShardedIndex::from_root_bytes(&empty_root)?;
+    assert!(matches!(
+        empty_index.load_shard(&empty_postings),
+        Err(ShardError::MalformedShard(_))
+    ));
+
+    let valid_shard = encode_test_shard(ShardId::new(0), "alpha", &[0], false);
+    let wrong_length_root = encode_test_root(
+        &posts,
+        ShardId::new(0),
+        "alpha",
+        &valid_shard,
+        Some(valid_shard.len() + 1),
+    );
+    let mut wrong_length_index = ShardedIndex::from_root_bytes(&wrong_length_root)?;
+    assert!(matches!(
+        wrong_length_index.load_shard(&valid_shard),
+        Err(ShardError::LengthMismatch { expected, actual, .. })
+            if expected == valid_shard.len() + 1 && actual == valid_shard.len()
+    ));
+
+    let mut malformed_count_root = ROOT_MAGIC.to_vec();
+    malformed_count_root.push(ROOT_VERSION);
+    let encoded_posts = encode_test_posts(&posts);
+    write_varint(&mut malformed_count_root, encoded_posts.len());
+    malformed_count_root.extend_from_slice(&encoded_posts);
+    write_varint(&mut malformed_count_root, usize::MAX);
+    let malformed_count_result = ShardedIndex::from_root_bytes(&malformed_count_root);
+    assert!(
+        matches!(malformed_count_result, Err(ShardError::MalformedRoot(_))),
+        "unexpected malformed-count result: {malformed_count_result:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn root_posts_reject_impossible_counts_and_nested_string_lengths() {
+    let mut impossible_count = Vec::new();
+    write_varint(&mut impossible_count, usize::MAX);
+    assert!(matches!(
+        ShardedIndex::from_root_bytes(&encode_root_with_post_payload(&impossible_count)),
+        Err(ShardError::MalformedRoot(_))
+    ));
+
+    for string_position in 0..3 {
+        let mut impossible_string = Vec::new();
+        write_varint(&mut impossible_string, 1);
+        for position in 0..=string_position {
+            if position == string_position {
+                write_varint(&mut impossible_string, usize::MAX);
+            } else {
+                write_string(&mut impossible_string, "");
+            }
+        }
+        assert!(matches!(
+            ShardedIndex::from_root_bytes(&encode_root_with_post_payload(&impossible_string)),
+            Err(ShardError::MalformedRoot(_))
+        ));
+    }
+
+    let mut trailing_post_bytes = Vec::new();
+    write_varint(&mut trailing_post_bytes, 0);
+    trailing_post_bytes.push(0);
+    assert!(matches!(
+        ShardedIndex::from_root_bytes(&encode_root_with_post_payload(&trailing_post_bytes)),
+        Err(ShardError::MalformedRoot(_))
+    ));
+}
+
+fn encode_test_shard(id: ShardId, term: &str, postings: &[usize], trailing: bool) -> Vec<u8> {
+    let mut bytes = SHARD_MAGIC.to_vec();
+    bytes.push(SHARD_VERSION);
+    write_varint(
+        &mut bytes,
+        usize::try_from(id.get()).expect("u32 fits usize"),
+    );
+    write_varint(&mut bytes, 1);
+    write_string(&mut bytes, term);
+    write_varint(&mut bytes, postings.len());
+    let mut previous = 0;
+    for (position, document) in postings.iter().copied().enumerate() {
+        let delta = if position == 0 {
+            document
+        } else {
+            document - previous
+        };
+        write_varint(&mut bytes, delta);
+        previous = document;
+    }
+    if trailing {
+        bytes.push(0);
+    }
+    bytes
+}
+
+fn encode_test_posts(posts: &[PostId]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    write_varint(&mut bytes, posts.len());
+    for post in posts {
+        write_string(&mut bytes, &post.title);
+        write_string(&mut bytes, &post.url);
+        write_string(&mut bytes, &post.meta);
+    }
+    bytes
+}
+
+fn encode_root_with_post_payload(post_payload: &[u8]) -> Vec<u8> {
+    let mut bytes = ROOT_MAGIC.to_vec();
+    bytes.push(ROOT_VERSION);
+    write_varint(&mut bytes, post_payload.len());
+    bytes.extend_from_slice(post_payload);
+    write_varint(&mut bytes, 0);
+    bytes
+}
+
+fn encode_test_root(
+    posts: &[PostId],
+    descriptor_id: ShardId,
+    term: &str,
+    shard: &[u8],
+    encoded_len_override: Option<usize>,
+) -> Vec<u8> {
+    let encoded_posts = encode_test_posts(posts);
+    let digest: [u8; 32] = Sha256::digest(shard).into();
+    let filename = format!("{}{SHARD_SUFFIX}", digest_hex(&digest));
+    let mut bytes = ROOT_MAGIC.to_vec();
+    bytes.push(ROOT_VERSION);
+    write_varint(&mut bytes, encoded_posts.len());
+    bytes.extend_from_slice(&encoded_posts);
+    write_varint(&mut bytes, 1);
+    write_varint(
+        &mut bytes,
+        usize::try_from(descriptor_id.get()).expect("u32 fits usize"),
+    );
+    write_string(&mut bytes, term);
+    write_string(&mut bytes, term);
+    write_varint(&mut bytes, encoded_len_override.unwrap_or(shard.len()));
+    bytes.extend_from_slice(&digest);
+    write_string(&mut bytes, &filename);
+    bytes
+}
+
+fn digest_hex(digest: &[u8; 32]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(64);
+    for &byte in digest {
+        output.push(char::from(HEX[usize::from(byte >> 4)]));
+        output.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    output
+}
+
+fn write_string(bytes: &mut Vec<u8>, value: &str) {
+    write_varint(bytes, value.len());
+    bytes.extend_from_slice(value.as_bytes());
+}
+
+fn write_varint(bytes: &mut Vec<u8>, mut value: usize) {
+    while value >= 0x80 {
+        bytes.push((value.to_le_bytes()[0] & 0x7f) | 0x80);
+        value >>= 7;
+    }
+    bytes.push(value.to_le_bytes()[0]);
+}

--- a/tests/wasm_loader_test.mjs
+++ b/tests/wasm_loader_test.mjs
@@ -1,0 +1,434 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import test from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const outputArgument = process.argv[2];
+if (!outputArgument) {
+    throw new Error('Usage: node tests/wasm_loader_test.mjs <generated-output-directory>');
+}
+if (typeof Response !== 'function') {
+    throw new Error('The WASM loader test requires Node.js 18 or newer (global Response is missing)');
+}
+
+const outputDirectory = path.resolve(outputArgument);
+const ROOT_MAGIC = Buffer.from('tinysearch-sharded-root');
+const SHARD_MAGIC = Buffer.from('tinysearch-shard');
+const PAGE_BYTES = 64 * 1024;
+
+function sleep(milliseconds) {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitFor(predicate, timeoutMs = 3_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (!predicate()) {
+        if (Date.now() >= deadline) {
+            throw new Error(`condition was not met within ${timeoutMs}ms`);
+        }
+        await sleep(5);
+    }
+}
+
+async function walk(directory) {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const nested = await Promise.all(entries.map(async (entry) => {
+        const filename = path.join(directory, entry.name);
+        return entry.isDirectory() ? walk(filename) : [filename];
+    }));
+    return nested.flat();
+}
+
+function startsWith(buffer, prefix) {
+    return buffer.length >= prefix.length && buffer.subarray(0, prefix.length).equals(prefix);
+}
+
+async function discoverArtifacts() {
+    const files = await walk(outputDirectory);
+    const wasmFiles = files.filter((filename) => filename.endsWith('.wasm'));
+    assert.equal(wasmFiles.length, 1, `expected one .wasm file, found: ${wasmFiles.join(', ')}`);
+
+    const javascriptFiles = files.filter((filename) => filename.endsWith('.js'));
+    const loaderMatches = [];
+    for (const filename of javascriptFiles) {
+        const source = await readFile(filename, 'utf8');
+        if (source.includes('initTinysearch') && source.includes('engine_plan_query')) {
+            loaderMatches.push(filename);
+        }
+    }
+    assert.equal(
+        loaderMatches.length,
+        1,
+        `expected one generated tinysearch loader, found: ${loaderMatches.join(', ')}`,
+    );
+
+    const roots = [];
+    const shards = [];
+    for (const filename of files) {
+        if (filename.endsWith('.wasm') || filename.endsWith('.js') || filename.endsWith('.html')) {
+            continue;
+        }
+        const bytes = await readFile(filename);
+        if (startsWith(bytes, ROOT_MAGIC)) {
+            roots.push(filename);
+        } else if (startsWith(bytes, SHARD_MAGIC)) {
+            shards.push(filename);
+        }
+    }
+    assert.equal(roots.length, 1, `expected one sharded root artifact, found: ${roots.join(', ')}`);
+    assert.ok(shards.length > 0, 'expected at least one lexical shard artifact');
+
+    const shardDirectories = new Set(shards.map((filename) => path.dirname(filename)));
+    assert.equal(
+        shardDirectories.size,
+        1,
+        `loader test expects descriptor filenames in one shard directory, found: ${[...shardDirectories].join(', ')}`,
+    );
+
+    return {
+        wasm: wasmFiles[0],
+        loader: loaderMatches[0],
+        root: roots[0],
+        shards,
+        shardDirectory: [...shardDirectories][0],
+    };
+}
+
+function createFileFetch({ wasmContentType = 'application/wasm', delayMs = 0 } = {}) {
+    const counts = new Map();
+    let failureUrl = null;
+    let failuresRemaining = 0;
+
+    const fetch = async (input) => {
+        const url = input instanceof URL
+            ? input
+            : new URL(typeof input === 'string' ? input : input.url);
+        counts.set(url.href, (counts.get(url.href) ?? 0) + 1);
+        if (delayMs > 0) {
+            await sleep(delayMs);
+        }
+
+        if (url.href === failureUrl && failuresRemaining > 0) {
+            failuresRemaining -= 1;
+            return new Response('injected shard failure', {
+                status: 503,
+                statusText: 'Injected Failure',
+            });
+        }
+        if (url.protocol !== 'file:') {
+            return new Response(`unsupported test URL ${url.href}`, { status: 400 });
+        }
+
+        try {
+            const bytes = await readFile(fileURLToPath(url));
+            const contentType = url.pathname.endsWith('.wasm')
+                ? wasmContentType
+                : 'application/octet-stream';
+            return new Response(bytes, {
+                status: 200,
+                headers: { 'content-type': contentType },
+            });
+        } catch (error) {
+            return new Response(`${error.code ?? 'read error'}: ${url.href}`, {
+                status: error.code === 'ENOENT' ? 404 : 500,
+            });
+        }
+    };
+
+    return {
+        fetch,
+        counts,
+        failOnce(url) {
+            failureUrl = String(url);
+            failuresRemaining = 1;
+        },
+    };
+}
+
+function countFor(controller, url) {
+    return controller.counts.get(String(url)) ?? 0;
+}
+
+function assertResultShape(result) {
+    assert.deepEqual(Object.keys(result).sort(), ['meta', 'title', 'url']);
+    assert.equal(typeof result.title, 'string');
+    assert.equal(typeof result.url, 'string');
+    assert.equal(typeof result.meta, 'string');
+}
+
+async function findLazyQuery(engine) {
+    const candidates = [
+        'review',
+        'plumber',
+        'podcast',
+        'firefox',
+        'calendar',
+        'millionaires',
+        'programming',
+        'sponsors',
+    ];
+    const plans = candidates.map((query) => ({ query, plan: engine.plan(query) }));
+    const match = plans.find(({ plan }) => plan.required.length > 0 && plan.required.length < engine.stats.shardCount);
+    assert.ok(
+        match,
+        `no candidate exercised a strict subset of ${engine.stats.shardCount} shards: ` +
+            plans.map(({ query, plan }) => `${query}=${plan.required.length}`).join(', '),
+    );
+    return match;
+}
+
+function optionsFor(artifacts, controller) {
+    return {
+        wasmUrl: pathToFileURL(artifacts.wasm),
+        rootUrl: pathToFileURL(artifacts.root),
+        shardBaseUrl: pathToFileURL(`${artifacts.shardDirectory}${path.sep}`),
+        fetch: controller.fetch,
+    };
+}
+
+function rawInputCall(engine, operation, bytes, ...args) {
+    const input = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    const ptr = input.byteLength === 0 ? 0 : engine.exports.engine_alloc(input.byteLength) >>> 0;
+    assert.ok(input.byteLength === 0 || ptr !== 0, `raw ${operation} input allocation failed`);
+    try {
+        if (input.byteLength > 0) {
+            new Uint8Array(engine.memory.buffer, ptr, input.byteLength).set(input);
+        }
+        return engine.exports[operation](ptr, input.byteLength, ...args) >>> 0;
+    } finally {
+        if (input.byteLength > 0) {
+            engine.exports.engine_dealloc(ptr, input.byteLength);
+        }
+    }
+}
+
+function readRawResponse(engine, handle) {
+    const ptr = engine.exports.engine_result_ptr(handle) >>> 0;
+    const len = engine.exports.engine_result_len(handle) >>> 0;
+    assert.ok(ptr > 0 && len > 0, `raw response handle ${handle} is invalid`);
+    try {
+        const bytes = new Uint8Array(engine.memory.buffer, ptr, len).slice();
+        return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+    } finally {
+        engine.exports.engine_result_free(handle);
+    }
+}
+
+class FakeInput extends EventTarget {
+    value = '';
+}
+
+test('generated sharded WASM loader is lazy, retryable, deduplicated, and bounded', async (context) => {
+    const artifacts = await discoverArtifacts();
+    const loaderUrl = pathToFileURL(artifacts.loader);
+    loaderUrl.searchParams.set('wasm-loader-test', String(Date.now()));
+    const { initTinysearch, init_tinysearch } = await import(loaderUrl.href);
+    assert.equal(typeof initTinysearch, 'function', 'generated loader must export initTinysearch');
+    assert.equal(typeof init_tinysearch, 'function', 'generated loader must export init_tinysearch');
+    assert.equal(init_tinysearch, initTinysearch, 'compatibility initializer must alias initTinysearch');
+
+    // A wrong MIME type forces instantiateStreaming to fail. The loader must
+    // fall back to the original response body without issuing a second fetch.
+    const mainFetch = createFileFetch({ wasmContentType: 'application/octet-stream' });
+    const engine = await initTinysearch(optionsFor(artifacts, mainFetch));
+    const wasmUrl = pathToFileURL(artifacts.wasm).href;
+    const rootUrl = pathToFileURL(artifacts.root).href;
+    assert.equal(countFor(mainFetch, wasmUrl), 1, 'initialization must fetch WASM exactly once');
+    assert.equal(countFor(mainFetch, rootUrl), 1, 'initialization must fetch the root exactly once');
+    assert.equal(engine.stats.loadedShardCount, 0, 'initialization must not eagerly load shards');
+    assert.equal(engine.stats.shardCount, artifacts.shards.length, 'root shard count must match emitted artifacts');
+
+    const handleFetch = createFileFetch();
+    const handleEngine = await init_tinysearch(optionsFor(artifacts, handleFetch));
+    const staleHandle = rawInputCall(
+        handleEngine,
+        'engine_plan_query',
+        new TextEncoder().encode('review'),
+    );
+    assert.ok(staleHandle > 0, 'raw plan must return a result handle');
+    const reloadHandle = rawInputCall(
+        handleEngine,
+        'engine_load_root',
+        await readFile(artifacts.root),
+    );
+    assert.ok(
+        reloadHandle > staleHandle,
+        `root reload reused or rewound result handles: stale=${staleHandle}, reload=${reloadHandle}`,
+    );
+    assert.equal(handleEngine.exports.engine_result_ptr(staleHandle) >>> 0, 0);
+    assert.equal(handleEngine.exports.engine_result_len(staleHandle) >>> 0, 0);
+    assert.equal(readRawResponse(handleEngine, reloadHandle).ok, true);
+
+    const { query: lazyQuery, plan: lazyPlan } = await findLazyQuery(engine);
+    const lazyResults = await engine.search(lazyQuery, 10);
+    assert.ok(lazyResults.length > 0, `known fixture query ${JSON.stringify(lazyQuery)} returned no results`);
+    lazyResults.forEach(assertResultShape);
+    assert.equal(engine.loadedUrls.length, lazyPlan.required.length);
+    assert.ok(
+        engine.loadedUrls.length < engine.stats.shardCount,
+        `lazy query loaded all ${engine.stats.shardCount} shards instead of a strict subset`,
+    );
+    for (const descriptor of lazyPlan.required) {
+        assert.equal(countFor(mainFetch, descriptor.url), 1, `required shard was not fetched once: ${descriptor.url}`);
+    }
+
+    const requestsBeforeRepeat = new Map(mainFetch.counts);
+    const repeated = await engine.search(lazyQuery, 10);
+    assert.deepEqual(repeated, lazyResults, 'repeated search results must be stable');
+    assert.deepEqual(mainFetch.counts, requestsBeforeRepeat, 'repeated search must not refetch loaded shards');
+
+    const unicodeResults = await engine.search(`${lazyQuery} 🦀 東京`, 10);
+    assert.ok(Array.isArray(unicodeResults), 'Unicode query must return a results array');
+    unicodeResults.forEach(assertResultShape);
+
+    const reviewResults = await engine.search('review', 10);
+    assert.ok(
+        reviewResults.some((result) => /review code/i.test(result.title)),
+        `known review search did not find “How To Review Code”: ${JSON.stringify(reviewResults.slice(0, 3))}`,
+    );
+    const plumberResults = await engine.search('plumber', 10);
+    assert.ok(
+        plumberResults.some((result) => /paolo.*plumber/i.test(result.title)),
+        `known plumber search did not find “Paolo the Plumber”: ${JSON.stringify(plumberResults.slice(0, 3))}`,
+    );
+
+    const concurrentFetch = createFileFetch();
+    const concurrentEngine = await initTinysearch(optionsFor(artifacts, concurrentFetch));
+    const concurrentPlan = concurrentEngine.plan(lazyQuery);
+    assert.ok(concurrentPlan.required.length > 0, 'concurrent dedupe query must require a shard');
+    const [concurrentA, concurrentB] = await Promise.all([
+        concurrentEngine.search(lazyQuery, 10),
+        concurrentEngine.search(lazyQuery, 10),
+    ]);
+    assert.deepEqual(concurrentA, concurrentB, 'concurrent searches must produce identical results');
+    for (const descriptor of concurrentPlan.required) {
+        assert.equal(
+            countFor(concurrentFetch, descriptor.url),
+            1,
+            `concurrent queries refetched shard ${descriptor.url}`,
+        );
+    }
+
+    const typeaheadFetch = createFileFetch({ delayMs: 20 });
+    const typeaheadEngine = await initTinysearch(optionsFor(artifacts, typeaheadFetch));
+    const supersededPlan = typeaheadEngine.plan('review');
+    const newestPlan = typeaheadEngine.plan('plumber');
+    assert.ok(supersededPlan.required.length > 0, 'superseded typeahead query must require a shard');
+    assert.ok(newestPlan.required.length > 0, 'newest typeahead query must require a shard');
+
+    const originalPlan = typeaheadEngine.plan.bind(typeaheadEngine);
+    const plannedQueries = [];
+    typeaheadEngine.plan = (query) => {
+        plannedQueries.push(String(query));
+        return originalPlan(query);
+    };
+    const fakeInput = new FakeInput();
+    const rendered = [];
+    const typeaheadErrors = [];
+    const detachTypeahead = typeaheadEngine.attachTypeahead(
+        fakeInput,
+        (items, query) => rendered.push({ items, query }),
+        {
+            debounceMs: 60,
+            onError: (error) => typeaheadErrors.push(error),
+        },
+    );
+
+    fakeInput.value = 'review';
+    fakeInput.dispatchEvent(new Event('input'));
+    await sleep(10);
+    fakeInput.value = 'plumber';
+    fakeInput.dispatchEvent(new Event('input'));
+    await waitFor(() => rendered.length > 0 || typeaheadErrors.length > 0);
+
+    assert.deepEqual(typeaheadErrors, [], 'debounced typeahead search should not fail');
+    assert.deepEqual(plannedQueries, ['plumber'], 'superseded input must not be planned');
+    assert.equal(rendered.length, 1, 'typeahead must render only the newest generation');
+    assert.equal(rendered[0].query, 'plumber');
+    assert.ok(
+        rendered[0].items.some((result) => /paolo.*plumber/i.test(result.title)),
+        'newest typeahead result should be rendered',
+    );
+    const newestShardUrls = new Set(newestPlan.required.map((descriptor) => descriptor.url));
+    const fetchedTypeaheadShards = [...typeaheadFetch.counts.keys()]
+        .filter((url) => url.endsWith('.tinysearch-shard'));
+    assert.ok(fetchedTypeaheadShards.length > 0, 'newest typeahead query should fetch a shard');
+    assert.ok(
+        fetchedTypeaheadShards.every((url) => newestShardUrls.has(url)),
+        `superseded typeahead fetched an unnecessary shard: ${fetchedTypeaheadShards.join(', ')}`,
+    );
+
+    const plannedBeforeCleanup = plannedQueries.length;
+    const renderedBeforeCleanup = rendered.length;
+    fakeInput.value = 'podcast';
+    fakeInput.dispatchEvent(new Event('input'));
+    detachTypeahead();
+    await sleep(90);
+    fakeInput.value = 'firefox';
+    fakeInput.dispatchEvent(new Event('input'));
+    await sleep(70);
+    assert.equal(plannedQueries.length, plannedBeforeCleanup, 'cleanup must cancel pending planning');
+    assert.equal(rendered.length, renderedBeforeCleanup, 'cleanup must prevent later rendering');
+
+    const retryFetch = createFileFetch();
+    const retryEngine = await initTinysearch(optionsFor(artifacts, retryFetch));
+    const retryPlan = retryEngine.plan(lazyQuery);
+    assert.ok(retryPlan.required.length > 0, 'retry query must require a shard');
+    const failedShard = retryPlan.required[0];
+    retryFetch.failOnce(failedShard.url);
+    await assert.rejects(
+        retryEngine.search(lazyQuery, 10),
+        (error) => {
+            assert.match(error.message, /503 Injected Failure/);
+            assert.match(error.message, new RegExp(failedShard.filename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+            return true;
+        },
+        'first injected shard fetch should fail',
+    );
+    const retried = await retryEngine.search(lazyQuery, 10);
+    assert.ok(retried.length > 0, 'search should succeed after retrying a failed shard fetch');
+    assert.equal(countFor(retryFetch, failedShard.url), 2, 'failed shard promise must be evicted for retry');
+
+    for (let iteration = 0; iteration < 20; iteration += 1) {
+        await engine.search(lazyQuery, 10);
+    }
+    const memoryBefore = engine.stats.wasmMemoryBytes;
+    const searchIterations = 250;
+    const timingStart = performance.now();
+    for (let iteration = 0; iteration < searchIterations; iteration += 1) {
+        await engine.search(lazyQuery, 10);
+    }
+    const warmedSearchTotalMs = performance.now() - timingStart;
+    const memoryAfter = engine.stats.wasmMemoryBytes;
+    const memoryGrowth = memoryAfter - memoryBefore;
+    assert.ok(
+        memoryGrowth <= 8 * PAGE_BYTES,
+        `WASM memory grew by ${memoryGrowth} bytes across ${searchIterations} repeated searches`,
+    );
+    assert.ok(
+        memoryGrowth < searchIterations * PAGE_BYTES,
+        'WASM memory appears to grow by a page per query (result handles may be leaking)',
+    );
+
+    const diagnostics = {
+        outputDirectory,
+        artifacts: {
+            wasm: path.basename(artifacts.wasm),
+            loader: path.basename(artifacts.loader),
+            root: path.basename(artifacts.root),
+            shardCount: artifacts.shards.length,
+        },
+        lazyQuery,
+        lazyShardCount: lazyPlan.required.length,
+        finalStats: engine.stats,
+        repeatedSearchMemoryGrowth: memoryGrowth,
+        warmedSearchTiming: {
+            iterations: searchIterations,
+            totalMs: Number(warmedSearchTotalMs.toFixed(3)),
+            averageMs: Number((warmedSearchTotalMs / searchIterations).toFixed(4)),
+        },
+    };
+    context.diagnostic(JSON.stringify(diagnostics, null, 2));
+});


### PR DESCRIPTION
## What this does

This PR adds lazy, query-driven index loading to TinySearch's exact WASM backend.

Instead of asking the browser to download one monolithic index before the first search, TinySearch now emits a small root index and a set of immutable lexical shards. The browser loads the root once. For each query, WASM works out which shards might contain matching terms, and JavaScript fetches only those files before running the search.

The generated artifact set now looks like this:

```text
tinysearch_engine.wasm
tinysearch_engine.js
tinysearch.root
<sha256>.tinysearch-shard
<sha256>.tinysearch-shard
...
```

I wrote up the format and query lifecycle in the [sharded-index design notes](https://github.com/tinysearch/tinysearch/blob/feature/sharded-index/docs/sharded-index.md).

## Where this started

I started with Stork's plan for [size-limited indexes loaded dynamically as the user types](https://github.com/jameslittle230/stork/issues/128). Stork's [2.0 beta](https://github.com/jameslittle230/stork/releases/tag/v2.0.0-beta.1) already had support for merging shards into a live index, although its builder did not yet split an index into those shards.

I liked the shape of that idea, especially the root index. I did not want to copy Stork's format directly, though. TinySearch has a smaller search model, existing exact and Xor8 backends, and a chance to use a fairly direct modern WASM interface. I treated Stork as useful prior art and then worked outward from TinySearch's own constraints.

The question I kept coming back to was simple: what is the smallest thing the browser needs before somebody starts typing?

The answer became a root containing result metadata and a compact map of the vocabulary. The larger posting lists live in shards and arrive only when a query can use them.

## How the pieces fit together

I settled on a fairly strict division of responsibilities:

- JavaScript owns fetching, retries, request deduplication, and browser URLs.
- WASM owns query normalization, shard routing, artifact validation, and ranking.

That split felt natural once I tried it. Browsers are already good at networking and caching. Rust is a better place for the format parser and the search rules. Keeping fetch out of WASM also leaves the engine independent of the corpus and hosting setup.

The core implementation lives in [`src/sharded.rs`](https://github.com/tinysearch/tinysearch/blob/feature/sharded-index/src/sharded.rs). It provides the root and shard formats, lexical partitioning, routing, validation, incremental loading, and the public sharded search API.

The exact WASM module in [`assets/crate/src/sharded_lib.rs`](https://github.com/tinysearch/tinysearch/blob/feature/sharded-index/assets/crate/src/sharded_lib.rs) exposes a small raw ABI with explicit allocation, deallocation, and result handles. I wanted memory ownership to be visible rather than hidden behind generated glue or an implicit `memory.grow()` path.

The loader in [`assets/tinysearch_loader.js`](https://github.com/tinysearch/tinysearch/blob/feature/sharded-index/assets/tinysearch_loader.js) coordinates the rest. It plans a query in WASM, shares in-flight shard requests, retries failed requests, loads the resulting bytes into the engine, and then runs the search. It also supports preloading, module-relative URLs, streaming WASM initialization, and a one-fetch fallback for servers with an incorrect WASM content type.

## Why the root contains result metadata

I considered putting result metadata into document-oriented shards to make the root even smaller. I decided against it.

If metadata lived elsewhere, finding the matching document IDs would only be the first half of a search. The loader would then need another round of requests before it could render titles and URLs. That request waterfall seemed like a poor trade for saving a few kilobytes in the root.

The root is still small, and once the lexical shards arrive, WASM can return complete results immediately.

## Why the shards are lexical

Each shard contains a contiguous range of normalized terms and their posting lists. WASM routes exact terms to the range that can contain them. Prefix queries may touch more than one range because valid completions can cross a shard boundary.

I made the router conservative on purpose. It may fetch a boundary shard that contributes no result, but it should never skip a valid completion.

I also partition by estimated encoded bytes instead of term count. A term with a long posting list weighs more than a rare term, so byte-based partitioning gives us more predictable network artifacts. The default target is 64 KiB before transport compression. A single oversized posting list stays intact and can exceed that target.

## Content-addressed publication

Every shard filename is the full SHA-256 digest of its encoded bytes:

```text
<sha256>.tinysearch-shard
```

I wanted unchanged parts of an index to keep the same URL between deployments. That lets a normal browser or CDN cache do most of the work without a TinySearch-specific cache layer.

The CLI publishes shards before it publishes the root. It keeps old immutable shards in place and writes the root last, so a visible root does not point to files that have not been published yet. If a shard already exists at a content address, the publisher verifies that its bytes match instead of silently overwriting it.

The CLI and high-level `TinySearch` API also sort documents canonically before assigning dense IDs. This keeps shard addresses stable when source documents arrive through an unordered `HashMap`. I left direct `ExactIndexBackend` callers in control of their input order because that order also determines equal-score result order.

## A few things I learned along the way

Encoded shard size and WASM memory are different numbers. After a shard is decoded, the engine keeps its terms and posting lists but discards the encoded byte buffer. The loader reports both the encoded lengths loaded so far and the current WASM linear-memory allocation so those costs are not confused.

Very small shards are not automatically better. They reduce the bytes behind an individual request, but they make the root larger and increase request fanout. On the repository fixture, 64 KiB was a better balance than aggressively small shards. I am treating that as a useful default, not a universal answer.

I also chose not to shard Xor8. The Xor8 backend stores a filter per document and needs to check every filter for a query. It cannot select a small lexical slice in the same way as the exact backend, so sharding it would add requests without providing the same benefit. Xor8 stays embedded, but its loader now has the same async shape and explicit query-memory ownership.

Finally, I kept the format validation deliberately strict. The root and shards are versioned envelopes, and the decoder checks IDs, lengths, hashes, ordering, posting bounds, UTF-8, and trailing bytes before accepting data. Since these artifacts can be hosted and cached independently, I would rather reject a mismatched set than produce plausible but incorrect results.

## Compatibility and migration

Existing monolithic exact v2 indexes and legacy Xor8 indexes remain readable.

Exact native crate generation still provides the embedded `search_local()` API. The root-and-shard artifact set applies to exact WASM output.

The generated JavaScript search API is now asynchronous:

```js
const engine = await initTinysearch();
const results = await engine.search('rust');
```

That is an intentional API change, so this PR moves the package version to `0.12.0`. I kept `init_tinysearch` as an alias for existing initialization code, but callers now need to await searches.

The [README](https://github.com/tinysearch/tinysearch/blob/feature/sharded-index/README.md) covers the public API, hosting behavior, and migration details.

## Benchmarks

I measured the repository fixture with the default 64 KiB raw shard target and `wasm-opt -Oz`. These numbers are a snapshot from this fixture and machine, not a promise for every corpus.

| Artifact | Raw | gzip | Brotli |
|---|---:|---:|---:|
| WASM | 100,623 B | 46,604 B | 39,400 B |
| JavaScript loader | 16,364 B | 4,394 B | 3,808 B |
| Root index | 5,179 B | 2,376 B | 2,001 B |
| Large shard | 65,528 B | 35,787 B | 31,307 B |
| Small shard | 12,003 B | 6,986 B | 6,026 B |

A representative cold query that needs one large shard transfers about **76.5 KiB with Brotli**, including WASM, loader, root, and shard.

For 250 warmed searches on the same fixture, I measured roughly:

```text
0.065 ms/search
0 bytes of WASM memory growth
```

I do not expect sharding to make the ranking loop dramatically faster. The practical win is that a visitor no longer has to transfer and decode posting lists that their query does not need.

## Tradeoffs and follow-up work

Loaded shards remain in WASM memory for the lifetime of the engine. I think that is the right starting point because it keeps repeated searches fast and the state model simple. If large, long-lived indexes need tighter memory bounds, we can add an eviction policy later with real usage data behind it.

Content-addressed shards also remain in the output directory between builds. I left garbage collection explicit because deleting old shards during a deployment can break a browser that still has an older root. Deployment tooling can remove unreachable shards once its cache and rollout policy says that is safe.

There is one small piece of duplication I chose not to hide in this PR: the canonical document comparator appears in both the high-level API and CLI preparation paths. Sharing it cleanly would require widening an API across the library and binary boundary or restructuring document preparation. I would rather leave that visible than introduce an awkward abstraction solely to remove a few lines.

This is a larger change than TinySearch usually carries, but I have tried to keep the model understandable: load a small root, ask WASM what the query needs, fetch immutable shards, and search with the same exact semantics as before.
